### PR TITLE
feat(saxo): OpenAPI 統合 (read-only OAuth) + 外部 API field 規律一般化 (ADR-025/026)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@
 | docs/gdr/ | 成長メカニズムの判断記録 |
 | docs/code-review-checklist.md | 統計・金融コードのレビュー基準（ADR-022） |
 | docs/testing-guidelines.md | 統計・金融コードのテスト設計原則（ADR-022） |
+| docs/api/ | 外部API公式仕様の集約（ADR-026、provider別） |
 
 ## Data Architecture (ADR-001)
 
@@ -30,6 +31,14 @@
 - FRED: 9シリーズ（公式、1-2日遅延）
 - Tiingo: 10シンボル日足 + 8シンボル5分足
 - yfinance: VIX/VIX3M/Brent即時取得（ProviderChainでFREDにフォールバック）
+- Saxo OpenAPI: 口座残高・ポジション (Live, OAuth, ADR-025)
+
+## 外部 API 統合 (ADR-026)
+
+- 全 provider の公式仕様は `docs/api/<provider>/` に集約 (Saxo は完全文書化済、他は段階的)
+- **API field の意味を変数名から推測しない**。`docs/api/<provider>/` を必ず参照
+- `src/*_client.py` 外部での raw dict キー access 禁止。意味的アクセサ経由のみ
+- 新規 provider 追加時は `docs/api/TEMPLATE.md` に従う
 
 ## DB Write基準 (ADR-003)
 

--- a/docs/adr/025-saxo-openapi-auth.md
+++ b/docs/adr/025-saxo-openapi-auth.md
@@ -1,0 +1,201 @@
+# ADR-025: Saxo OpenAPI 認証情報の配置設計
+
+Status: proposed
+Date: 2026-05-26
+
+## Context
+
+Master Sensei が brokerage の **現金残高・口座別ポジション・通貨情報** を取得できない設計欠陥が顕在化した (2026-05-26 セッション)。
+
+### 顕在化した問題
+
+ユーザが「残現金を SOXL に追加投入するか」を相談した際、以下の質問に DB が答えられなかった:
+- 口座 P120136 の現金残高
+- 口座 T126816 の現金残高
+- NAV (現金 + 含み資産)
+- ポジション size が NAV の何 %
+- Kelly 推奨 size の算出
+
+`trades` テーブルは個別 trade の `pnl_usd/pnl_pct` を持つが、口座別 cash balance も初期入金額も追跡していない。累計 realized PnL (-$572.60) を出しても残現金には換算不能。
+
+ユーザの Saxo 取引明細 Excel (`Transactions_22013145_2026-03-11_2026-05-25.xlsx`) からは復元可能 (P120136: 21,901 JPY ≈ $138 / T126816: 103,099 JPY ≈ $649) だが、毎セッション手動 DL は摩擦が大きく、自動化が必要。
+
+### 選択肢の絞り込み経緯
+
+Step 1: データ源として **Saxo OpenAPI 直接統合 (D案)** を選択
+- Excel sync (C案) と比較し、リアルタイム性・運用摩擦・portability で D 優位
+- `saxo_openapi` (pypi, hootnot) wrapper 既存
+- 必要 endpoint: `pf.balances.AccountBalancesMe`, `pf.positions.PositionsMe`
+
+Step 2: 認証フローとして **OAuth 2.0 (Authorization Code grant + refresh)** を選択
+- 24h Dev Portal token は毎日ブラウザ手動コピペが必要 → SoT 原則 (ADR-008) に反する摩擦
+- OAuth なら初回認可後、60〜90日間は無人で refresh 継続可能
+- 自動化された scan-market・signal-check 等の skill を将来増やす際の前提条件
+
+Step 3: token 配置として **DB (DuckDB) vs `.env`** が論点に → 本 ADR で確定
+
+### token 配置の論点
+
+OAuth access token は **20 分で失効** し、refresh のたびに refresh token も rotate する (各 refresh で旧 refresh token は無効化)。1セッション中も複数回 rotate するため、`.env` への書き戻しは:
+- env ファイル mutation = anti-pattern (12-factor)
+- 同時 process が複数あると競合
+- 失効履歴・取得経緯の audit が不能
+- SIM/Live 環境の token 区別が困難 (単一 `SAXO_TOKEN=` では)
+
+一方 App Key/Secret は **月〜年単位で不変の静的 config** で、性質が異なる。
+
+## Options
+
+| 選択肢 | 長所 | 短所 | 採否 |
+|--------|------|------|------|
+| A. 全部 `.env` (App Key/Secret + token) | 実装最小 | token 自動書き戻しが anti-pattern、audit 不能、multi-env 困難 | 不採用 |
+| **B. ハイブリッド (App Key/Secret は `.env`、token は DB)** | **静的config と 動的state の関心分離、ADR-009 精神と一貫、multi-env対応、audit可能** | テーブル 1個追加 | **採用** |
+| C. macOS Keychain (`security` cmd 経由) | OS 標準で暗号化保管 | macOS 専用、可搬性低、inspect 手間、過剰 | 不採用 |
+| D. 暗号化 vault (HashiCorp Vault 等) | 本格的秘密管理 | 個人 local 用途で過剰 | 不採用 |
+
+## Decision
+
+> **Option B (ハイブリッド) を採用する。** 以下を実施する:
+>
+> 1. **静的 credentials は `.env`** に配置する:
+>    ```
+>    SAXO_APP_KEY=...
+>    SAXO_APP_SECRET=...
+>    SAXO_REDIRECT_URI=http://localhost:8080/callback
+>    SAXO_ENVIRONMENT=live   # 'sim' | 'live'
+>    ```
+>    `.env` は git管理外 (`.gitignore` 確認)、`chmod 600`。
+>
+> 2. **DuckDB に `auth_tokens` テーブルを新設する。** schema:
+>    ```sql
+>    CREATE TABLE auth_tokens (
+>        id INTEGER PRIMARY KEY,
+>        provider VARCHAR NOT NULL,            -- 'saxo' (将来 'fred' 等拡張)
+>        environment VARCHAR NOT NULL,         -- 'sim' | 'live'
+>        token_type VARCHAR NOT NULL,          -- 'access' | 'refresh'
+>        token_value VARCHAR NOT NULL,
+>        acquired_at TIMESTAMP WITH TIME ZONE NOT NULL,
+>        expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+>        acquired_via VARCHAR,                 -- 'oauth_initial' | 'oauth_refresh' | 'dev_portal_manual'
+>        refresh_count INTEGER DEFAULT 0,
+>        metadata JSON,                        -- response 生 payload (audit)
+>        revoked_at TIMESTAMP WITH TIME ZONE,
+>        created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+>    );
+>    CREATE INDEX idx_auth_active ON auth_tokens(provider, environment, token_type)
+>        WHERE revoked_at IS NULL;
+>    ```
+>    append-only。expired/revoked record は削除せず audit 保持。
+>
+> 3. **SenseiDB に helper を追加する:**
+>    - `save_token(provider, environment, token_type, token_value, expires_at, acquired_via, metadata=None) -> int`
+>    - `get_active_token(provider, environment, token_type) -> dict | None` (期限内未失効の最新 1件)
+>    - `revoke_token(id, reason)` (refresh失敗時等)
+>
+> 4. **OAuth クライアント `src/saxo_client.py` を新設する:**
+>    - 起動時に `get_active_token('saxo', env, 'access')` を試行
+>    - 期限切れなら refresh token で access token 更新 → 両方 `save_token`
+>    - refresh token も期限切れなら例外 raise → ユーザに `/saxo-reauth` 実行を促す
+>
+> 5. **初回認可 CLI `scripts/saxo_oauth_init.py` を作成する:**
+>    - ローカル HTTP サーバ起動 (port 8080)
+>    - Saxo 認可URLをブラウザで開く
+>    - callback で code 受領 → token endpoint 叩いて初回 access+refresh token 取得
+>    - DB に保存
+>    - 60〜90日に1回再実行
+>
+> 6. **Saxo Live OpenAPI app の App Key/Secret は 2026-05-26 取得済み** (申請 lead time 想定 1〜2営業日に対し実際は即日発行)。`.env` に `SAXO_APP_KEY_LIVE` / `SAXO_APP_SECRET_LIVE` / `SAXO_AUTH_URL_LIVE` / `SAXO_TOKEN_URL_LIVE` として配置済み。SIM 用変数 (`*_SIM`) は将来用に空欄保持、本実装では参照しない。
+
+## Rationale
+
+### なぜ DB に token を置くか
+
+1. **ADR-009 の精神と一貫**: regime_assessments で入力値スナップショットを必須化したのと同じ思想 — auth state も「いつ取得したか・いつ失効するか・何回 refresh したか」が後から監査可能であるべき
+2. **OAuth 仕様への適合**: refresh token は使用ごとに rotate するため、永続化先は「mutation 安全」な store でなければならない。DB は ACID、`.env` は手作業前提
+3. **multi-env 自然対応**: SIM/Live を `environment` カラムで分離。`.env` では `SAXO_TOKEN_SIM=` / `SAXO_TOKEN_LIVE=` の二重定義必要
+4. **audit & debugging**: refresh 失敗が連続したら DB の `acquired_at`/`expires_at`/`refresh_count` を SQL で時系列確認できる
+5. **無人実行と整合**: 将来 cron 化された skill が token を消費しても、`.env` 編集なしで動き続ける
+
+### なぜ App Key/Secret は `.env` か
+
+1. **性質が違う**: アプリ申請時に1回発行、月〜年単位で不変。rotation 概念がない
+2. **bootstrap 必要**: DB から credentials を読むには DB 接続が必要、その認証情報を DB に置くと循環
+3. **12-factor config**: 配備依存の static 値は env が正解。direnv 等の OS 標準ツールに乗る
+4. **token 漏洩時の影響範囲分離**: DB が漏れても App Secret は別ファイルに守られる (depth in defense)
+
+### なぜ Keychain ではないか
+
+- 個人 macOS local 専用なので OS keychain の暗号化は overkill
+- `security` cmd 経由の read/write は inspect 困難で debug 摩擦
+- 可搬性低 (Linux/Windows 移植不可)
+- DB ファイルも `chmod 600` で同等のアクセス制御は可能
+
+## Charter Impact
+
+- **Charter 3.3 MAP 分析**: NAV/cash 数値に基づく Kelly フラクション議論が初めて DB 駆動で可能になる (現在は会話依存)
+- **Charter 5.x 自己評価**: 「ポジション size が NAV の何 % で entry したか」が trades に対して計算可能になり、過大ベット/過小ベットの review 精度が向上
+- **ADR-001 データガバナンス**: brokerage state を扱う領域を明示的に scope-in する初の ADR (ADR-001 のスコープを補正)
+
+## Consequences
+
+### 反映先
+
+- **新規ファイル**:
+  - `src/saxo_client.py` (OAuth wrapper, token lifecycle 管理)
+  - `scripts/saxo_oauth_init.py` (初回認可 CLI)
+  - `scripts/saxo_oauth_init.py` のテスト
+  - `tests/test_db_auth_tokens.py` (DB helper のテスト)
+- **既存ファイル変更**:
+  - `src/db.py`: `auth_tokens` テーブル定義 + helper 3 メソッド追加
+  - `requirements.txt`: `saxo_openapi` 追加
+  - `.env.example`: `SAXO_APP_KEY` 等のテンプレート追加 (実値は `.env` に)
+  - `.gitignore`: `.env` 確認 (既存のはず)
+- **連動する skill 設計 (別 ADR で扱う、本 ADR では対象外)**:
+  - `/portfolio-sync` 新設 (balances + positions 取得 → DB の portfolio_snapshots に書き込み)
+  - `/entry-analysis` 改修 (NAV ベースの sizing 議論)
+  - SessionStart hook で token 期限警告 (例: 残 7日以下で警告)
+
+### トレードオフ
+
+- ストレージ: token rotation で `auth_tokens` が成長。1日 ~20 record × 365日 = 7,300 record/年、1record < 1KB なので影響軽微
+- 実装コスト: 初期 5-8 時間 (saxo_openapi 動作確認、OAuth CLI、テスト)
+- Saxo API 仕様変更リスク: wrapper 経由でも raw `requests` でも同じリスク。endpoint URI 変更時は src/saxo_client.py のみ修正
+- Live OpenAPI app 申請 lead time 1〜2営業日 (SIM 環境で並行開発可能)
+
+### 見直しトリガー
+
+- **複数 broker 対応が必要になった場合** → `auth_tokens` の `provider` カラム拡張で対応済み (再設計不要)
+- **token rotation 頻度が secondary 単位に上がった場合** (Saxo 仕様変更等) → DB I/O コスト見直し
+- **マルチユーザ化した場合** (現状は個人専用) → `user_id` カラム追加、credentials 暗号化検討
+- **Master Sensei が VPS/cloud 移行した場合** → Vault 等の本格 secret 管理への移行検討
+
+### 実装段階
+
+| Phase | 内容 | 状態 / 前提 |
+|-------|------|------|
+| 1 | Saxo SIM app 作成 + Live app 申請 | **完了** (2026-05-26、Live は審査待ちなしで即発行) |
+| 2 | `auth_tokens` テーブル + `SenseiDB` helper 実装 + テスト | Phase 1 完了済み、即着手可 |
+| 3 | (optional) SIM 環境で OAuth flow 動作確認 | **省略可**。SIM の役割は (a) Live app 申請の前提条件、(b) 発注テスト用、(c) API 探索用。本プロジェクトは Live app 発行済み + read-only のためいずれも不要。rate limit 観点でも 1セッション 2 req/分 vs 120 req/分 で余裕あり、SIM 節約効果ゼロ |
+| 4 | Live 環境で OAuth flow 実装 + 動作確認 (主路) | Phase 2 完了後 |
+| 5 | `/portfolio-sync` skill 新設 (別 ADR) | Phase 4 完了後 |
+
+`.env` の `SAXO_*_SIM` 用 4変数は将来 24h dev token で素早く動作確認したい場合に備え空欄保持。コードからは参照しない。
+
+### SIM スキップの根拠 (調査結果)
+
+公式ドキュメント (https://www.developer.saxo/openapi/learn/rate-limiting) で確認した rate limit:
+- アプリ全体: 1,000万 req/日
+- セッション × サービスグループ: 120 req/分
+
+Master Sensei の用途 (balances + positions = 2 req/セッション) では制限の **60倍以上の余裕**。「SIM で quota 節約」の動機なし。OAuth token に「消費」概念は OAuth 仕様上そもそも存在せず、rate limit のみが制約。
+
+SIM/Live で rate limit が別カウントかは公式ドキュメントに記載なし (credentials が独立なので別カウントの可能性高いが推測)。本プロジェクトの request 量規模ではこの差異も実害ゼロ。
+
+### 実装タイミング
+
+- 設計確定: 本 ADR で 2026-05-26
+- 実装: Phase 2-4 は本日〜翌日。Phase 5 は別 ADR で起案
+
+## 関連 ADR
+
+- **ADR-026 (外部 API field 解釈規律)**: 本 ADR 実装中に Saxo Balance field 解釈で致命的誤りが発生。その教訓を一般化した規律。Saxo は ADR-026 適用第1号 (`docs/api/saxo/` 完全文書化、意味的アクセサ実装)。今後の Saxo endpoint 追加・他 provider 統合時は ADR-026 を必読。

--- a/docs/adr/026-external-api-field-discipline.md
+++ b/docs/adr/026-external-api-field-discipline.md
@@ -1,0 +1,160 @@
+# ADR-026: 外部 API field 解釈の規律
+
+Status: proposed
+Date: 2026-05-26
+
+## Context
+
+2026-05-26 のセッションで、Saxo OpenAPI の Portfolio/Balances レスポンスを解釈する際、Master Sensei が **`CashBalance` フィールドを「取引可能額」だと変数名から推測** し、ユーザに「T126816 の今夜使える現金は $96 のみ」と誤った報告を行った。
+
+実際の事実 (公式 schema 参照):
+- `CashBalance: 15,216 JPY` (settled cash balance)
+- `CashAvailableForTrading: 103,099 JPY` (取引可能額、broker 仕様で未決済込み)
+- `SpendingPower: 103,099 JPY` (同上)
+- `TransactionsNotBooked: 87,882 JPY` (T+2 未決済分)
+
+→ 正しい usable cash は **$96 ではなく $649** であり、SOXL 3株まで追加可能。誤情報を実トレード判断に反映した場合、機会損失または不適切な position sizing につながる致命的誤り。
+
+### 根本原因
+
+- 外部 API レスポンスのフィールド意味を **公式 spec で確認せず、英語の変数名から推測** した
+- 同一レスポンス内に類似名の field (`CashBalance` vs `CashAvailableForTrading` vs `SpendingPower`) が複数存在することを認識せず、最初に目に入った値を採用
+- 解釈の根拠 (citation) を示さずに数値を提示
+- ユーザに「何を根拠に？」と問われるまで誤りに気付かなかった
+
+### 既存の整合性
+
+CLAUDE.md は既に以下を定めている:
+- 「事実と推測は分離。推測には確信度(%)を付与」
+- 「設計判断や分析の提案前に十分な調査と根拠を提示する。直感で提案しない」
+
+しかし **外部 API field の意味解釈** はこれら原則の盲点だった。「直感で提案しない」が API field level まで適用されていなかった。
+
+### 規模
+
+本プロジェクトは複数の外部 API に依存:
+- 既存: FRED (`src/fred_client.py`), Tiingo (`src/tiingo_client.py`), yfinance, Saxo (`src/saxo_client.py` 新規)
+- 計画中: Polygon, 他 broker, news API 等
+
+→ Saxo 固有の対症療法では同種ミスが他 provider で再発する。**規律として一般化** する必要がある。
+
+## Options
+
+| 選択肢 | 長所 | 短所 | 採否 |
+|--------|------|------|------|
+| A. 現状維持 (CLAUDE.md「事実と推測の分離」原則のみ) | 追加コストゼロ | API field level の盲点が残る、同種ミス再発確実 | 不採用 |
+| **B. provider 別 doc + コード規約 + CLAUDE.md ルール** | 構造的に推測を抑止、provider 追加が機械的 | 初期文書化コスト | **採用** |
+| C. 自動化 skill (`/api-field-check`) | 強制力強い | SoT 原則 (CLAUDE.md 既述) と矛盾、過剰自動化 | 不採用 |
+| D. type generation (Saxo OpenAPI spec → pydantic) | 型安全、強制力最大 | Saxo OpenAPI spec が機械可読 form で公開されていない、メンテコスト | 不採用 (検討候補として保留) |
+
+## Decision
+
+> **Option B (provider 別 doc + コード規約 + CLAUDE.md ルール) を採用する。** 以下を実施する:
+>
+> 1. **`docs/api/` ディレクトリ構造を新設する:**
+>    ```
+>    docs/api/
+>    ├── README.md      # 全 provider index
+>    ├── policy.md      # 本 ADR の運用ポリシー詳細
+>    ├── TEMPLATE.md    # 新規 provider 追加時の雛形
+>    └── <provider>/
+>        ├── README.md
+>        ├── <topic>.md
+>        └── ...
+>    ```
+>
+> 2. **provider doc の必須項目:**
+>    - 各 field の公式定義 (出典 URL 必須)
+>    - 「公式 doc にない」場合は明示 (推測しない)
+>    - 「**本プロジェクトでこの用途に使うべき field はどれか**」の判断指針 (用途別の正解 field を表で示す)
+>    - 実例レスポンス (PII マスク済み)
+>
+> 3. **コード規約 (`src/*_client.py` 全般に適用):**
+>    - 外部 API レスポンスの **raw dict キー access を、client モジュール外部から行うことを禁止**
+>    - client モジュール内に **意味的アクセサ** (e.g., `get_spending_power()`) を定義し、外部からはこれ経由のみアクセス
+>    - 各意味的アクセサの docstring に `docs/api/<provider>/<file>.md#<field>` を citation
+>    - raw dict を返す method (`get_balances()` 等) は残してよいが、docstring に「sizing 判断には `get_spending_power()` を使え」を明記
+>
+> 4. **CLAUDE.md に「外部 API 統合」セクション追加 (5行以内)** — 必読ルールと doc 所在を index。
+>
+> 5. **`docs/code-review-checklist.md` に項目追加** — レビュー時に raw dict 直 access を検出する。
+>
+> 6. **既存 provider (FRED, Tiingo, yfinance) の retroactive 文書化** は別タスク化。Saxo (本 ADR 起案の原因) は本日中に完全文書化。
+
+## Rationale
+
+### なぜ provider 別 doc か
+
+- Claude Code 公式 best practice (`https://code.claude.com/docs/en/best-practices`) に「Give URLs for documentation and API references. Claude can read API docs — what it can't infer is your team's patterns」とある
+- 公式 doc を丸ごとコピーしないが、**「team固有の用途別 field 選択」は明文化** が必要
+- provider ごとにディレクトリを分けることで、新規 provider 追加が `TEMPLATE.md` をコピーするだけで済む
+
+### なぜコード規約 (意味的アクセサ) か
+
+- doc を読む規律だけでは「dict キーを直接書く」誘惑を構造的に防げない
+- 意味的アクセサを必須にすることで、誤った field を選んだ瞬間にコード上で見える (PR review/grep で発見可能)
+- 既存 `src/fred_client.py` `src/tiingo_client.py` は単一値 (`value`) を返す薄い wrapper なのでこの問題は表面化していないが、Saxo のように複数 field を返す API では essential
+
+### なぜ自動化 skill ではないか
+
+- CLAUDE.md「Memory運用ルール」「SoT はリポジトリ内」原則と整合
+- 規律は人間が読める doc + コード規約で表現するのが本プロジェクトの設計思想
+- 自動化は摩擦を上げる (skill 呼び出し忘れで形骸化)
+
+### なぜ type generation (Option D) を保留か
+
+- Saxo OpenAPI が機械可読 form で公開されている確証なし (developer portal は SPA で WebFetch では schema 取得困難)
+- pydantic / dataclass 生成は強力だが、複数 provider それぞれ仕様取得方法が異なる
+- 「provider が公式 OpenAPI/Swagger spec を提供している場合のみ」という条件で将来導入検討
+
+## Charter Impact
+
+- Charter 5.x「自己評価」: 「変数名から推測した」誤りを root_cause として認識し、構造的予防策を講じる原則を確立
+- ADR-022「code-review-standards」の延長: 統計・金融コードレビュー基準に **外部 API field 解釈** を加える
+- CLAUDE.md「事実と推測は分離」原則の **API field level への拡張**
+
+## Consequences
+
+### 反映先
+
+- 新規ファイル:
+  - `docs/api/README.md`
+  - `docs/api/policy.md`
+  - `docs/api/TEMPLATE.md`
+  - `docs/api/saxo/README.md`
+  - `docs/api/saxo/balance-fields.md`
+  - `docs/api/saxo/endpoints.md`
+  - `docs/api/saxo/rate-limits.md`
+- 既存ファイル変更:
+  - `src/saxo_client.py`: 意味的アクセサ追加 + raw dict method の docstring 更新
+  - `tests/test_saxo_client.py`: 意味的アクセサのテスト追加
+  - `CLAUDE.md`: 「外部 API 統合 (ADR-026)」セクション追加
+  - `docs/code-review-checklist.md`: raw dict 直 access 禁止項目追加
+  - `docs/adr/025-saxo-openapi-auth.md`: 本 ADR への cross-reference 追記
+
+### トレードオフ
+
+- 初期文書化コスト ~70分 (Saxo 1 provider 分)
+- 各 provider 追加時に TEMPLATE に従う必要 (10-20分程度の overhead)
+- 意味的アクセサ追加で client モジュールの行数増加 (許容範囲)
+
+### 見直しトリガー
+
+- **Saxo が公式 OpenAPI spec (JSON/YAML) を提供開始した場合** → Option D (type generation) 導入検討
+- **provider 数が 10 を超え、TEMPLATE の更新負荷が高まった場合** → 共通 base class (`BaseAPIClient`) 導入検討
+- **本ルール遵守違反が code review で複数回発見された場合** → 自動化検出 (lint rule 等) 導入検討
+
+### 既存 provider への遡及適用
+
+| Provider | 状態 | 対応 |
+|----------|------|------|
+| Saxo | 新規 (本 ADR 起案契機) | 本日中に完全文書化 + 意味的アクセサ |
+| FRED | 既存、シリーズ単純 (`value` のみ) | 別タスク (TEMPLATE 適用、low priority) |
+| Tiingo | 既存、daily/intraday 仕様あり | 別タスク (medium priority) |
+| yfinance | 既存、unofficial wrapper | 別タスク (caveat 集として high priority) |
+
+### 実装タイミング
+
+- 設計確定: 本 ADR で 2026-05-26
+- Saxo 実装: 本日中 (米寄り 22:30 JST までに完了させる)
+- 既存 provider 遡及: 別セッションタスクとして登録

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,25 @@
+# 外部 API リファレンス index (ADR-026)
+
+Master Sensei が依存する外部 API の公式仕様を集約。
+
+## 必読ポリシー
+
+- [policy.md](policy.md) — 推測禁止・citation 必須・raw dict 禁止の原則
+- [TEMPLATE.md](TEMPLATE.md) — 新規 provider 追加時の雛形
+
+## Provider 一覧
+
+| Provider | code module | 用途 | doc 完成度 |
+|----------|-------------|------|----------|
+| [saxo/](saxo/README.md) | `src/saxo_client.py` | 口座残高・ポジション (OAuth, ADR-025) | ✅ 完全文書化 |
+| fred/ (未作成) | `src/fred_client.py` | マクロ指標 9 シリーズ (FOMC, CPI 等) | ⏳ 別タスク |
+| tiingo/ (未作成) | `src/tiingo_client.py` | 株価 daily / intraday | ⏳ 別タスク |
+| yfinance/ (未作成) | `src/providers.py` (chain) | VIX, VIX3M, Brent 即時取得 | ⏳ 別タスク |
+
+## 新規 provider 追加手順
+
+1. `cp -r docs/api/saxo docs/api/<provider>` または `cp TEMPLATE.md docs/api/<provider>/README.md`
+2. 公式 spec の URL を citation として埋めながら各 field を文書化
+3. `src/<provider>_client.py` に意味的アクセサを実装 (raw dict 露出禁止)
+4. 本 README の「Provider 一覧」表に追記
+5. テスト追加 (アクセサごとに最低1 case)

--- a/docs/api/TEMPLATE.md
+++ b/docs/api/TEMPLATE.md
@@ -1,0 +1,45 @@
+# <Provider 名> API リファレンス
+
+## 概要
+
+- **公式 doc**: <URL>
+- **code module**: `src/<provider>_client.py`
+- **認証方式**: <e.g., OAuth 2.0 / API Key / なし>
+- **rate limit**: <e.g., 50 req/hour、詳細は rate-limits.md>
+- **本プロジェクトでの用途**: <e.g., 株価日足取得、レジーム判定用マクロ取得>
+
+## ファイル
+
+| ファイル | 内容 |
+|---------|------|
+| README.md | 本ファイル。概要 + 早見表 |
+| <topic>-fields.md | レスポンス field の公式定義 (citation 必須) |
+| endpoints.md | 使用 endpoint 一覧 + 実例レスポンス |
+| rate-limits.md | rate limit 公式値 |
+| auth.md | 認証フロー (該当時) |
+
+## 用途別 field 早見表
+
+**重要**: API レスポンスを解釈する前に必ず参照する。変数名からの推測禁止 (ADR-026)。
+
+| 用途 | 使う field | 注意 |
+|------|----------|------|
+| <例: 新規取引の sizing> | <field 名> | <落とし穴があれば記載> |
+| <例: 会計表示> | <field 名> | <別 field との混同注意> |
+
+## 意味的アクセサ (src/<provider>_client.py)
+
+| アクセサ | 返す field | 用途 |
+|---------|----------|------|
+| `<method>()` | `<FieldName>` | <用途> |
+
+## 既知の落とし穴
+
+- <例: field A と field B が似た名前だが意味が違う、公式 doc URL>
+- <例: 環境 (SIM/Live) で挙動差があるなら明記>
+
+## 参考リンク
+
+- 公式 reference: <URL>
+- glossary: <URL>
+- changelog: <URL>

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -1,0 +1,90 @@
+# 外部 API 統合ポリシー (ADR-026 詳細)
+
+## 原則 3点
+
+### 1. 推測禁止 (variable-name inference 禁止)
+
+外部 API レスポンスのフィールド意味を、英語の変数名から推測してはならない。
+
+❌ 悪い例: 「`CashBalance` だから取引可能な現金だろう」
+✅ 良い例: 「公式 schema doc では `CashBalance` = "Current cash balance" (settled cash only)、取引可能額は `CashAvailableForTrading` または `SpendingPower`」 (出典: https://www.developer.saxo/openapi/referencedocs/port/v1/balances/...)
+
+### 2. citation 必須
+
+各 field 説明には公式 doc の URL を必ず併記する。「公式 doc に記載なし」の場合は明示する (推測で補完しない)。
+
+### 3. raw dict access 禁止 (code level)
+
+外部 API レスポンスを `dict["FieldName"]` で直接読むコードを `src/*_client.py` の **外部** に書いてはならない。client モジュール内に意味的アクセサを定義し、外部からはこれ経由のみ。
+
+## なぜこのポリシーか
+
+2026-05-26 セッションで Saxo `CashBalance` を「取引可能額」と誤解釈し、ユーザに「$96 のみ」と報告。実際は `CashAvailableForTrading: $649` で 6.7倍 の乖離。トレード判断の根幹である position sizing を誤らせる致命的バグ。
+
+詳細: [ADR-026](../adr/026-external-api-field-discipline.md) Context 節
+
+## doc 配置規約
+
+各 provider は `docs/api/<provider>/` に以下を持つ:
+
+| ファイル | 内容 |
+|---------|------|
+| README.md | provider 概要、endpoint catalog、よく使う field の早見表 |
+| `<topic>-fields.md` | 各 field の公式定義 + citation (例: `balance-fields.md`) |
+| endpoints.md | 使用する endpoint 一覧 + 実例レスポンス (PII マスク) |
+| rate-limits.md | rate limit 公式値 |
+| auth.md | 認証フロー (該当する場合) |
+
+公式 doc が SPA で WebFetch しづらい場合は **実際の API レスポンスを最小例として記録** する (response key の網羅性を担保)。
+
+## コード規約
+
+### 必須: 意味的アクセサ
+
+```python
+class SaxoClient:
+    def get_spending_power(self, account_key: str) -> float:
+        """口座の取引可能額 (SpendingPower、未決済込み)。
+
+        See docs/api/saxo/balance-fields.md#spendingpower
+        """
+        return float(self._get_balance(account_key)["SpendingPower"])
+
+    def get_settled_cash_balance(self, account_key: str) -> float:
+        """settled cash のみ (CashBalance、会計表示用)。
+        sizing 判断には get_spending_power() を使うこと。
+
+        See docs/api/saxo/balance-fields.md#cashbalance
+        """
+        return float(self._get_balance(account_key)["CashBalance"])
+```
+
+### 許可: raw dict 取得 (調査用途のみ)
+
+```python
+def get_balances(self) -> dict:
+    """raw レスポンス全体を返す。
+    **sizing 判断には get_spending_power() / get_settled_cash_balance() を使うこと。**
+    この method は schema 確認・新 field 発見等の調査用途のみ。
+
+    See docs/api/saxo/balance-fields.md
+    """
+```
+
+### 禁止: client 外部での dict キー access
+
+```python
+# ❌ 禁止
+balances = client.get_balances()
+cash = balances["CashBalance"]  # field 意味の推測リスク
+
+# ✅ 推奨
+cash = client.get_spending_power(account_key)
+```
+
+## レビュー時のチェックポイント
+
+`docs/code-review-checklist.md` に追加:
+- `src/*_client.py` 外部で `["FieldName"]` パターンの dict access がないか grep
+- 新 endpoint 使用時、対応する意味的アクセサが追加されているか
+- 各意味的アクセサに `docs/api/...` citation があるか

--- a/docs/api/saxo/README.md
+++ b/docs/api/saxo/README.md
@@ -1,0 +1,59 @@
+# Saxo OpenAPI リファレンス
+
+## 概要
+
+- **公式 doc**: https://www.developer.saxo/openapi/learn/
+- **reference docs**: https://www.developer.saxo/openapi/referencedocs
+- **code module**: `src/saxo_client.py`
+- **認証方式**: OAuth 2.0 (Authorization Code grant、ADR-025)
+- **rate limit**: アプリ全体 1,000万 req/日、セッション×サービスグループ 120 req/分 ([rate-limits.md](rate-limits.md))
+- **本プロジェクトでの用途**: Live 口座 (P120136 等 7 sub-accounts) の現金残高・open positions 取得
+
+## ファイル
+
+| ファイル | 内容 |
+|---------|------|
+| README.md | 本ファイル |
+| [balance-fields.md](balance-fields.md) | Balance response の全 field 公式定義 (citation 必須) |
+| [endpoints.md](endpoints.md) | 使用 4 endpoint + 実例レスポンス |
+| [rate-limits.md](rate-limits.md) | rate limit 公式値 |
+
+## 用途別 field 早見表
+
+**重要**: 解釈前に必ず balance-fields.md を参照 (ADR-026)。
+
+| 用途 | 使う field | 使ってはいけない field | 理由 |
+|------|----------|--------------------|------|
+| **新規取引の sizing (今夜 SOXL 何株買えるか)** | `CashAvailableForTrading` または `SpendingPower` | `CashBalance` | CashBalance は settled cash のみ。未決済分 (TransactionsNotBooked) を含まないため過小評価する |
+| 口座評価額 (NAV) | `TotalValue` | `CashBalance` | TotalValue = cash + 未実現ポジション評価額 |
+| 含み損益確認 | `UnrealizedPositionsValue` | - | |
+| margin 必要量算出 | `NetEquityForMargin` | `TotalValue` | NetEquityForMargin が margin 計算の正式 base |
+| margin 余力確認 | `MarginAvailableForTrading` | `CashAvailableForTrading` | margin instrument (CFD/FX) では別の field |
+
+## 意味的アクセサ (src/saxo_client.py)
+
+| アクセサ | 返す field | 用途 |
+|---------|----------|------|
+| `get_spending_power(account_key)` | `SpendingPower` | sizing 判断 (これを使う) |
+| `get_cash_available_for_trading(account_key)` | `CashAvailableForTrading` | sizing 判断 (SpendingPower と同じ値、互換性のため) |
+| `get_settled_cash_balance(account_key)` | `CashBalance` | 会計表示用 (sizing には使わない) |
+| `get_total_value(account_key)` | `TotalValue` | NAV |
+| `get_unrealized_pnl(account_key)` | `UnrealizedPositionsValue` | 含み損益 |
+| `get_transactions_not_booked(account_key)` | `TransactionsNotBooked` | T+2 未決済額 (debug 用) |
+| `get_balances()` (raw) | 全 field | 調査用途のみ |
+
+## 既知の落とし穴
+
+### CashBalance vs CashAvailableForTrading vs SpendingPower
+
+3つとも英語名が似ているが意味が違う。**取引余力は CashAvailableForTrading / SpendingPower のみ**。CashBalance は settled cash 表示用で、未決済を含まない (= 過小評価する)。
+
+2026-05-26 セッションで T126816 の取引余力を `CashBalance` から $96 と誤解釈。実際は `SpendingPower` から $649 (差 6.7倍)。詳細: [ADR-026](../../adr/026-external-api-field-discipline.md)
+
+### 7 sub-accounts
+
+`/port/v1/accounts/me` は 7口座 (I161277 / N122798 / P120136 / S153624 / T126816 / TU130134 / X153099) を返す。Excel 取引履歴に登場するのは P120136 / T126816 のみだが、他 5 口座も active (現状残高 0)。
+
+### Position の CurrentPrice = 0
+
+米市場休場中は `PositionView.CurrentPrice` / `MarketValue` が 0 で返る。価格情報は別途 `/trade/v1/prices/` か Parquet (close price) を使う。

--- a/docs/api/saxo/balance-fields.md
+++ b/docs/api/saxo/balance-fields.md
@@ -1,0 +1,257 @@
+# Saxo Balance Response Fields
+
+`/port/v1/balances` および `/port/v1/balances/me` の response object 全 field の公式定義。
+
+**出典 (Primary)**: [Saxo Developer Portal - BalanceResponse schema](https://www.developer.saxo/openapi/referencedocs/port/v1/balances/post__port__subscriptions/schema-balanceresponse)
+**出典 (Secondary, user-facing)**:
+- [Saxo Support - What is Cash available?](https://www.help.saxo/hc/en-us/articles/360031172191-What-is-Cash-available)
+- [Saxo Glossary - Cash balance](https://www.home.saxo/content/glossary/cash-balance)
+
+## Cash 系 fields
+
+### CashBalance
+
+- **型**: Number
+- **公式定義** (Saxo schema): "Current cash balance of the account/client."
+- **公式定義** (Saxo glossary): "The current value of the cash funds in your account."
+- **用途**: settled cash の会計表示
+- **本プロジェクトでの推奨**: ❌ **sizing 判断に使わない** (未決済を含まないため過小評価)。`get_settled_cash_balance()` 経由で会計表示用途のみ
+- **実例 (2026-05-26 T126816)**: 15,216.61 JPY (実際の取引余力 103,099 JPY とは別物)
+
+### CashAvailableForTrading
+
+- **型**: Number
+- **公式定義** (schema): "Cash available for trading for the current account/client."
+- **公式定義** (Saxo Support):
+  > "Cash available is the funds available for withdrawal or for buying cash products (stocks, bonds, funds, options)."
+- **含むもの**: 現金残高 + 未決済取引 + 株式/ETF/債券/ファンド評価額 (ヘアカット後) + オプション時価 + margin 損益
+- **含まないもの**: 企業行動 (corporate action) 関連の発生額
+- **制約**: "Cash Available can never exceed initial margin available"
+- **本プロジェクトでの推奨**: ✅ **sizing 判断に使う**。`get_cash_available_for_trading()` 経由
+- **実例 (2026-05-26 T126816)**: 103,099 JPY (settled 15,216 + TransactionsNotBooked 87,882)
+
+### SpendingPower
+
+- **型**: Number
+- **公式定義** (schema): "Available spending power on the account/client." (`SpendingPowerDetail` object として返される構造もあり)
+- **本プロジェクトでの観測**: `CashAvailableForTrading` と同値 (103,099 JPY)
+- **本プロジェクトでの推奨**: ✅ **sizing 判断に使う**。`get_spending_power()` 経由 (CashAvailableForTrading と互換)
+- **注意**: 値が CashAvailableForTrading と同じか異なるかは口座種別 (cash account vs margin account) で変わる可能性あり。本プロジェクトの cash account では同値だが、将来 margin 利用時は再検証
+
+### CashBlocked
+
+- **型**: Number
+- **公式定義**: "Cash blocked for the current account/client."
+- **本プロジェクトでの推奨**: 通常 0。0 でない場合は調査必要
+
+### CashBlockedFromWithdrawal
+
+- **型**: Number
+- **公式定義**: ページに記載なし (推測なし、必要時は Saxo Support に確認)
+- **本プロジェクトでの観測**: 通常 0
+
+### TransactionsNotBooked
+
+- **型**: Number
+- **公式定義**: "Value of transactions that have yet to be booked..."
+- **意味**: T+1/T+2 未決済の取引額。CashAvailableForTrading にはこの分も含まれる
+- **本プロジェクトでの推奨**: debug/audit 用途。`get_transactions_not_booked()` で参照可
+- **実例 (2026-05-26 T126816)**: 87,882 JPY (5/22 SOXL 3株売却 $555 ≒ 88,245 JPY 相当)
+
+### SettlementValue
+
+- **型**: Number
+- **公式定義**: "Net current settlement value, long and short..."
+- **本プロジェクトでの推奨**: 現在用途なし
+
+## Value 系 fields
+
+### TotalValue
+
+- **型**: Number
+- **公式定義**: "Current value of unrealized positions incl. cash balance..."
+- **意味**: NAV (cash + 未実現ポジション評価額)
+- **本プロジェクトでの推奨**: ✅ NAV 表示・position size 比率算出に使う。`get_total_value()` 経由
+- **実例 (2026-05-26 P120136)**: 52,151 JPY (cash 21,901 + SOXL 1株 30,250)
+
+### UnrealizedPositionsValue
+
+- **型**: Number
+- **公式定義**: "The current unrealized profit/loss and face value..."
+- **本プロジェクトでの推奨**: 含み損益確認。`get_unrealized_pnl()` 経由
+
+### UnrealizedPositionsValueExcludingCostToClosePositions
+
+- **型**: Number
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの推奨**: 通常用途なし。UnrealizedPositionsValue を使う
+
+### NonMarginPositionsValue
+
+- **型**: Number
+- **公式定義**: "Sum of MarketValue for all non-margin instruments held..."
+- **意味**: cash instrument (ETF, 株式等) の合計評価額
+- **本プロジェクトでの観測 (P120136)**: 30,251.61 JPY (SOXL 1株 $190.56 × FX)
+
+### CostToClosePositions
+
+- **型**: Number
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの観測**: 負値で記録される (P120136: -176.21)
+
+## Margin 系 fields
+
+### MarginAvailableForTrading
+
+- **型**: Number
+- **公式定義**: "Margin available for trading..."
+- **本プロジェクトでの推奨**: cash account では通常使わない。CFD/FX 利用時に重要
+
+### NetEquityForMargin
+
+- **型**: Number
+- **公式定義**: "Value used as basis to calculate maintinance margin."
+- **本プロジェクトでの推奨**: margin 計算 base 値 (現状用途なし)
+
+### CollateralAvailable
+
+- **型**: Number
+- **公式定義**: "Sum of collateral from positions, cash, collateral..."
+- **本プロジェクトでの推奨**: 現状用途なし
+
+### CollateralCreditValue
+
+- **型**: dict (構造)
+- **本プロジェクトでの推奨**: 現状用途なし
+
+### InitialMargin
+
+- **型**: Number
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの推奨**: cash account では 0
+
+### MarginCollateralNotAvailable
+
+- **型**: 構造 (詳細: `MarginCollateralNotAvailableDetail`)
+- **本プロジェクトでの推奨**: 現状用途なし
+
+### MarginAndCollateralUtilizationPct
+
+- **型**: Number
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの推奨**: 現状用途なし
+
+## Position count 系 fields
+
+### OpenPositionsCount
+
+- **型**: Integer
+- **公式定義**: "Number of current open positions."
+- **本プロジェクトでの推奨**: ✅ open position 数の確認
+
+### ClosedPositionsCount
+
+- **型**: Integer
+- **公式定義**: "Number of current closed positions."
+- **意味**: 同日中にクローズした position 数 (settling 中含む可能性)
+- **本プロジェクトでの観測 (T126816)**: 1 (5/22 SOXL 3株 entry → 同日 exit)
+
+### NetPositionsCount
+
+- **型**: Integer
+- **公式定義**: "Number of current open net positions."
+- **本プロジェクトでの観測**: open + 未決済 closed の合計と推測 (公式定義あいまい)
+
+### OpenIpoOrdersCount / OrdersCount / TriggerOrdersCount
+
+- **型**: Integer
+- **本プロジェクトでの推奨**: 現状用途なし
+
+## 損益系 fields
+
+### UnrealizedMarginProfitLoss / UnrealizedMarginOpenProfitLoss / UnrealizedMarginClosedProfitLoss
+
+- **型**: Number
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの観測**: cash account では全て 0
+
+### OptionPremiumsMarketValue
+
+- **型**: Number
+- **本プロジェクトでの推奨**: option 取引なし、常に 0
+
+## メタ系 fields
+
+### Currency
+
+- **型**: VARCHAR
+- **意味**: 口座通貨 (JPY / USD 等)
+- **本プロジェクトでの観測**: 5 口座 JPY、2 口座 USD
+
+### CurrencyDecimals
+
+- **型**: Integer
+- **意味**: 通貨の小数点桁数 (JPY: 0, USD: 2 等)
+
+### CalculationReliability
+
+- **型**: VARCHAR
+- **公式定義**: ページに記載なし
+- **本プロジェクトでの観測**: "Ok" (正常時)
+- **本プロジェクトでの推奨**: "Ok" 以外の値は調査必要
+
+### IsPortfolioMarginModelSimple
+
+- **型**: Boolean
+- **本プロジェクトでの観測**: True (cash account)
+
+### CorporateActionUnrealizedAmounts
+
+- **型**: Number
+- **本プロジェクトでの観測**: 0 (現状コーポレートアクションなし)
+
+### FinancingAccruals
+
+- **型**: Number
+- **本プロジェクトでの観測**: 0 (margin/CFD 未利用)
+
+### ChangesScheduled
+
+- **型**: Boolean
+- **公式定義**: ページに記載なし
+
+### ExtendedTradingHoursData / ExtendedTradingHoursUncertaintyValue
+
+- **型**: 構造 / Number
+- **本プロジェクトでの推奨**: 時間外取引利用時のみ
+
+### SrdSpendingPower
+
+- **型**: Number (推測)
+- **公式定義**: ページに記載なし (推測せず、必要時は Saxo Support 確認)
+- **本プロジェクトでの観測 (T126816)**: 103,099 (SpendingPower と同値)
+
+### SpendingPowerDetail
+
+- **型**: dict
+- **公式定義** (schema): "Available spending power on the account/client." (構造化版)
+- **本プロジェクトでの推奨**: 詳細不要時は flat な `SpendingPower` を使う
+
+### TransactionsNotBookedDetail
+
+- **型**: dict
+- **本プロジェクトでの観測 (T126816)**: 4 key の構造 (T+2 settling の trade 内訳)
+
+### MarginCollateralNotAvailableDetail
+
+- **型**: dict (2 key)
+- **本プロジェクトでの推奨**: 現状用途なし
+
+### OtherCollateral
+
+- **型**: Number
+- **本プロジェクトでの観測**: 0
+
+## 改訂履歴
+
+- 2026-05-26: 初版作成。Saxo Live API 実レスポンス (P120136 / T126816) を基に全 field を網羅。公式 schema から取得できなかった field は「ページに記載なし」と明示。

--- a/docs/api/saxo/endpoints.md
+++ b/docs/api/saxo/endpoints.md
@@ -1,0 +1,146 @@
+# Saxo OpenAPI 使用 endpoints
+
+base URL (Live): `https://gateway.saxobank.com/openapi`
+base URL (SIM): `https://gateway.saxobank.com/sim/openapi`
+
+公式: https://www.developer.saxo/openapi/learn/environments
+
+## 認証
+
+全 endpoint は `Authorization: Bearer <access_token>` 必須。
+access token 取得は ADR-025 (OAuth 2.0 Authorization Code grant) 参照。
+
+## 使用 endpoint 一覧
+
+### 1. GET /port/v1/accounts/me
+
+ログイン中ユーザの全 sub-account を取得。
+
+- 公式: https://www.developer.saxo/openapi/referencedocs/port/v1/accounts
+- code: `SaxoClient.get_accounts()`
+- 返り値: `Data` 配列 (各要素が account dict)
+
+**実例レスポンス** (2026-05-26 取得、PII 部分マスク):
+```json
+{
+  "Data": [
+    {
+      "AccountId": "77800/P120136",
+      "AccountKey": "9SdaOVfmGO3Se0gt1q3N...",
+      "ClientKey": "...",
+      "Currency": "JPY",
+      "Active": true
+    },
+    {"AccountId": "77800/T126816", "Currency": "JPY", "Active": true},
+    {"AccountId": "77800/N122798", "Currency": "USD", "Active": true},
+    ...
+  ]
+}
+```
+
+- 主要 field: `AccountId`, `AccountKey`, `ClientKey`, `Currency`, `Active`
+- 注意: `AccountKey` は API call で必須の identifier。`AccountId` は人間可読 (口座番号)
+
+### 2. GET /port/v1/balances/me
+
+ログイン中ユーザの **aggregated** balance (全 sub-account 合算、base currency 換算)。
+
+- 公式: https://www.developer.saxo/openapi/referencedocs/port/v1/balances
+- code: `SaxoClient.get_balances()`
+- 返り値: 1個の balance dict (全 field は [balance-fields.md](balance-fields.md))
+
+**本プロジェクトでの推奨**: 口座別が必要なので endpoint #3 を使うこと。`/me` の aggregate は USD/JPY 混在で解釈困難 (2026-05-26 観測: CashBalance=37,117 JPY と全 JPY 口座合計 125,000 JPY が乖離 — JPY base に集約された結果と推測されるが詳細未確認)
+
+### 3. GET /port/v1/balances?AccountKey={key}&ClientKey={key}
+
+**口座別 balance** を取得。
+
+- code: `SaxoClient._api_get(f"/port/v1/balances?AccountKey={k}&ClientKey={c}")` (内部 method 経由)
+- 返り値: 1個の balance dict (口座固有)
+
+**実例レスポンス** (2026-05-26 P120136、SOXL 1株保有):
+```json
+{
+  "CalculationReliability": "Ok",
+  "CashAvailableForTrading": 21901.0,
+  "CashBalance": 21901.0,
+  "CashBlocked": 0.0,
+  "Currency": "JPY",
+  "NetEquityForMargin": 21901.0,
+  "NetPositionsCount": 1,
+  "NonMarginPositionsValue": 30251.61,
+  "OpenPositionsCount": 1,
+  "SpendingPower": 21901.0,
+  "TotalValue": 52152.61,
+  "TransactionsNotBooked": 0.0,
+  "UnrealizedPositionsValue": 30075.0
+}
+```
+
+**実例レスポンス** (2026-05-26 T126816、5/22 SOXL 売却 T+2 settling 中):
+```json
+{
+  "CashBalance": 15216.61,           // 注: settled only、sizing には使わない
+  "CashAvailableForTrading": 103099.0,  // ← sizing にはこれを使う
+  "SpendingPower": 103099.0,            // ← 同値
+  "TransactionsNotBooked": 87882.39,    // ← 5/22 SOXL 売却の T+2 未決済分
+  "TotalValue": 103099.0,
+  ...
+}
+```
+
+### 4. GET /port/v1/positions/me
+
+open positions のリスト。
+
+- code: `SaxoClient.get_positions()` (内部で `Data` 配列を返す)
+- 返り値: position dict のリスト
+
+**主要 field**:
+- `PositionBase.AccountId`: どの口座のポジションか
+- `PositionBase.Uic`: instrument の一意 ID (e.g., SOXL = 46780)
+- `PositionBase.Amount`: 数量 (正=long、負=short)
+- `PositionBase.OpenPrice`: entry price
+- `PositionView.CurrentPrice`: 現在価格 (米市場休場中は 0)
+- `PositionView.MarketValue`: 市場評価額 (米市場休場中は 0)
+- `PositionView.ProfitLossOnTradeInBaseCurrency`: 含み損益 (base currency = JPY)
+
+**実例レスポンス** (2026-05-26、P120136 の SOXL 1株):
+```json
+{
+  "PositionBase": {
+    "AccountId": "77800/P120136",
+    "Uic": 46780,
+    "Amount": 1.0,
+    "OpenPrice": 176.0
+  },
+  "PositionView": {
+    "CurrentPrice": 0.0,           // 米市場休場のため 0
+    "MarketValue": 0.0,
+    "ProfitLossOnTradeInBaseCurrency": 2342.0  // ≒ +$14.76 (FX 158.67)
+  },
+  "DisplayAndFormat": {
+    "Description": null,           // FieldGroup パラメタなしのため null
+    "Symbol": null
+  }
+}
+```
+
+**注意**:
+- `DisplayAndFormat` の中身を取得するには `?FieldGroups=DisplayAndFormat,PositionView` 等の query parameter が必要。本プロジェクトはまだ未対応 (Uic から symbol 逆引きが必要なら別途実装)
+- 米市場休場中の `CurrentPrice` = 0 問題: Parquet の close price で代替
+
+## token endpoint (OAuth 用、Portfolio とは別)
+
+### POST https://live.logonvalidation.net/token
+
+- 用途: code 交換 + token refresh
+- code 実装: `SaxoClient.exchange_code_for_tokens()`, `SaxoClient._refresh_access_token()`
+- ADR-025 参照
+
+## 未使用 endpoint (将来検討)
+
+- `/trade/v1/orders/me`: 発注 (本プロジェクトは read-only、未使用)
+- `/trade/v1/prices/`: リアルタイム価格 (米市場休場対策で将来検討)
+- `/port/v1/closedpositions/me`: クローズ済 position 履歴
+- `/cs/v1/audit/orderactivities/me`: 取引履歴 audit

--- a/docs/api/saxo/rate-limits.md
+++ b/docs/api/saxo/rate-limits.md
@@ -1,0 +1,45 @@
+# Saxo OpenAPI Rate Limits
+
+**公式**: https://www.developer.saxo/openapi/learn/rate-limiting
+
+## 制限値 (公式記載)
+
+| Dimension | 上限 |
+|-----------|-----|
+| アプリ全体 | **10,000,000 req/日** (max number of requests per application across all users and sessions) |
+| セッション × サービスグループ | **120 req/分** (max per session per service group) |
+| 発注 (per session) | **1 req/秒** (only for orders) |
+
+## 超過時
+
+- HTTP **429 Too Many Requests** 返却
+- Identical order operations が 15秒以内に来た場合は HTTP **409 Conflict** (unique `x-request-id` header で回避可能)
+
+## レスポンスヘッダ
+
+各レスポンスに含まれる:
+- `X-RateLimit-<dimension>-Limit`
+- `X-RateLimit-<dimension>-Remaining`
+- `X-RateLimit-<dimension>-Reset`
+
+`<dimension>` は AppDay, AppMinute, AccountMinute 等 (詳細は公式 doc)。
+
+## 本プロジェクトでの実需要
+
+1セッションで以下程度:
+- `get_accounts()` 1 req
+- `get_balances()` × 7 sub-accounts = 7 req
+- `get_positions()` 1 req
+- 合計 ~10 req
+
+→ **120 req/分 の 10% 程度**、制限に対して 12倍の余裕。
+→ 1日 1,000万 req 制限には到底届かない。
+
+## SIM vs Live の差
+
+公式 doc に記載なし。本プロジェクトは Live のみ使用。
+
+## 注意点
+
+- rate limit に近づいた場合、レスポンスヘッダ `X-RateLimit-*-Remaining` で残量を確認できる
+- 現実装 (`src/saxo_client.py`) は rate limit ヘッダを利用していない。利用量が増えたら client 側で throttle 実装を検討

--- a/docs/code-review-checklist.md
+++ b/docs/code-review-checklist.md
@@ -56,7 +56,18 @@ Created: 2026-04-02
 - [ ] テストで同一 seed が同一結果を保証するか
 - [ ] 浮動小数点の比較に適切な許容誤差（pytest.approx等）を使っているか
 
-## 4. テスト設計
+## 4. 外部 API 統合 (ADR-026)
+
+- [ ] `src/*_client.py` 外部に `["FieldName"]` パターンの raw dict access が無いか (`grep -rn '\["[A-Z][a-zA-Z]*"\]' src/ scripts/`)
+- [ ] 新規 endpoint 使用時、対応する意味的アクセサが `src/<provider>_client.py` に追加されているか
+- [ ] 各意味的アクセサに `docs/api/<provider>/<file>.md#<field>` の citation コメントがあるか
+- [ ] field 意味の解釈に推測が含まれていないか (公式 doc 未記載のものは "ページに記載なし" と明示)
+- [ ] 新規 provider 追加時、`docs/api/<provider>/` を `TEMPLATE.md` に従って作成しているか
+- [ ] `docs/api/README.md` の provider 一覧表が最新か
+
+事例: 2026-05-26、Saxo `CashBalance` を `CashAvailableForTrading` と混同し position sizing を誤った (ADR-026 Context)
+
+## 5. テスト設計
 
 テスト設計の詳細原則は @docs/testing-guidelines.md を参照。
 

--- a/scripts/saxo_oauth_init.py
+++ b/scripts/saxo_oauth_init.py
@@ -13,8 +13,10 @@ Authorization Code grant の初回フローを対話的に実行する:
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import logging
 import secrets
+import stat
 import sys
 import threading
 import webbrowser
@@ -32,6 +34,9 @@ from src.saxo_client import SaxoAuthError, SaxoClient, SaxoConfig
 logger = logging.getLogger(__name__)
 
 DB_PATH = Path(__file__).parent.parent / "data" / "sensei.duckdb"
+
+# ADR-025: token_value plaintext を含む DB ファイルは owner-only にする
+DB_FILE_MODE = stat.S_IRUSR | stat.S_IWUSR  # 0o600
 
 
 class _CallbackResult:
@@ -53,6 +58,12 @@ def _make_handler(expected_state: str, result: _CallbackResult):
                 self.end_headers()
                 return
 
+            # idempotency: 既に callback 処理済みなら何もしない (race 防止)
+            if result.event.is_set():
+                self.send_response(200)
+                self.end_headers()
+                return
+
             params = parse_qs(parsed.query)
             received_state = (params.get("state") or [None])[0]
             received_code = (params.get("code") or [None])[0]
@@ -61,7 +72,10 @@ def _make_handler(expected_state: str, result: _CallbackResult):
             if received_error:
                 result.error = received_error
             elif received_state != expected_state:
-                result.error = f"state mismatch: expected={expected_state!r} got={received_state!r}"
+                # SECURITY: expected_state は session secret なので error message に含めない
+                result.error = (
+                    f"state mismatch: callback returned unexpected state (got={received_state!r})"
+                )
             elif not received_code:
                 result.error = "no code in callback"
             else:
@@ -87,11 +101,45 @@ def _make_handler(expected_state: str, result: _CallbackResult):
     return CallbackHandler
 
 
+def _validate_loopback_host(host: str | None) -> None:
+    """redirect_uri の host が loopback 専用であることを保証 (network exposure 防止)"""
+    if host is None:
+        raise SystemExit(
+            "SAXO_REDIRECT_URI hostname could not be parsed. "
+            "Ensure URI starts with http:// and includes host (e.g., http://localhost:8080/callback)"
+        )
+    if host == "localhost":
+        return
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        raise SystemExit(
+            f"SAXO_REDIRECT_URI host must be 'localhost' or a loopback IP, got {host!r}"
+        )
+    if not addr.is_loopback:
+        raise SystemExit(
+            f"SAXO_REDIRECT_URI host must be a loopback address (127.0.0.1 or ::1), got {host!r}. "
+            "Binding to non-loopback exposes the OAuth callback to the network."
+        )
+
+
+def _ensure_db_file_mode(path: Path) -> None:
+    """DB ファイルが存在すれば 0o600 に強制 (ADR-025)"""
+    if path.exists():
+        try:
+            path.chmod(DB_FILE_MODE)
+        except OSError as exc:
+            logger.warning("Could not chmod %s to 0o600: %s", path, exc)
+
+
 def run_oauth_init(environment: str | None = None, port: int = 8080,
                    open_browser: bool = True) -> None:
     config = SaxoConfig.from_env(environment=environment)
-    expected_host = urlparse(config.redirect_uri).hostname
-    expected_port = urlparse(config.redirect_uri).port
+    parsed_redirect = urlparse(config.redirect_uri)
+    expected_host = parsed_redirect.hostname
+    expected_port = parsed_redirect.port
+
+    _validate_loopback_host(expected_host)
     if expected_port != port:
         raise SystemExit(
             f"Port mismatch: SAXO_REDIRECT_URI port={expected_port} but CLI port={port}. "
@@ -99,6 +147,7 @@ def run_oauth_init(environment: str | None = None, port: int = 8080,
         )
 
     conn = duckdb.connect(str(DB_PATH))
+    _ensure_db_file_mode(DB_PATH)
     db = SenseiDB(conn)
     try:
         client = SaxoClient(db, config=config)
@@ -111,27 +160,30 @@ def run_oauth_init(environment: str | None = None, port: int = 8080,
         server_thread = threading.Thread(target=server.serve_forever, daemon=True)
         server_thread.start()
 
-        print(f"[saxo-oauth-init] environment: {config.environment}")
-        print(f"[saxo-oauth-init] listening on http://{expected_host}:{port}/callback")
-        print(f"[saxo-oauth-init] Open this URL in your browser if it does not open automatically:")
-        print(f"\n  {auth_url}\n")
-        if open_browser:
-            webbrowser.open(auth_url)
+        try:
+            print(f"[saxo-oauth-init] environment: {config.environment}")
+            print(f"[saxo-oauth-init] listening on http://{expected_host}:{port}/callback")
+            print(f"[saxo-oauth-init] Open this URL in your browser if it does not open automatically:")
+            print(f"\n  {auth_url}\n")
+            if open_browser:
+                webbrowser.open(auth_url)
 
-        # 5分待機。手動ログインが終わるまで block。
-        if not result.event.wait(timeout=300):
+            # 5分待機。手動ログインが終わるまで block。
+            if not result.event.wait(timeout=300):
+                raise SystemExit("[saxo-oauth-init] timeout waiting for callback (5 min)")
+
+            if result.error:
+                raise SystemExit(f"[saxo-oauth-init] callback error: {result.error}")
+
+            print("[saxo-oauth-init] code received, exchanging for tokens...")
+            client.exchange_code_for_tokens(code=result.code)
+            print(f"[saxo-oauth-init] OK. access + refresh tokens saved to {DB_PATH}")
+        finally:
             server.shutdown()
-            raise SystemExit("[saxo-oauth-init] timeout waiting for callback (5 min)")
-        server.shutdown()
-
-        if result.error:
-            raise SystemExit(f"[saxo-oauth-init] callback error: {result.error}")
-
-        print("[saxo-oauth-init] code received, exchanging for tokens...")
-        client.exchange_code_for_tokens(code=result.code)
-        print(f"[saxo-oauth-init] OK. access + refresh tokens saved to {DB_PATH}")
+            server.server_close()
     finally:
         conn.close()
+        _ensure_db_file_mode(DB_PATH)
 
 
 def main():

--- a/scripts/saxo_oauth_init.py
+++ b/scripts/saxo_oauth_init.py
@@ -1,0 +1,156 @@
+"""Saxo OpenAPI 初回認可 CLI (ADR-025)
+
+Authorization Code grant の初回フローを対話的に実行する:
+  1. localhost:8080 で一時 HTTP サーバ起動
+  2. Saxo 認可URLをブラウザで開く
+  3. ユーザが Saxo にログイン → callback で code 受領
+  4. code を access+refresh token に交換 → DuckDB に保存
+  5. サーバ停止
+
+実行: python scripts/saxo_oauth_init.py
+再実行が必要なタイミング: refresh token 期限切れ (60〜90日に1回)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import secrets
+import sys
+import threading
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import duckdb
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.db import SenseiDB
+from src.saxo_client import SaxoAuthError, SaxoClient, SaxoConfig
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = Path(__file__).parent.parent / "data" / "sensei.duckdb"
+
+
+class _CallbackResult:
+    """callback で受け取った code / state / error を保持する worker shared state"""
+
+    def __init__(self):
+        self.code: str | None = None
+        self.state: str | None = None
+        self.error: str | None = None
+        self.event = threading.Event()
+
+
+def _make_handler(expected_state: str, result: _CallbackResult):
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if not parsed.path.startswith("/callback"):
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            params = parse_qs(parsed.query)
+            received_state = (params.get("state") or [None])[0]
+            received_code = (params.get("code") or [None])[0]
+            received_error = (params.get("error") or [None])[0]
+
+            if received_error:
+                result.error = received_error
+            elif received_state != expected_state:
+                result.error = f"state mismatch: expected={expected_state!r} got={received_state!r}"
+            elif not received_code:
+                result.error = "no code in callback"
+            else:
+                result.code = received_code
+                result.state = received_state
+
+            body = (
+                b"<html><body><h2>Saxo OAuth callback received</h2>"
+                b"<p>You can close this tab and return to the terminal.</p>"
+                b"</body></html>"
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            result.event.set()
+
+        def log_message(self, format, *args):
+            # quiet down stdlib HTTPServer's stderr logging
+            pass
+
+    return CallbackHandler
+
+
+def run_oauth_init(environment: str | None = None, port: int = 8080,
+                   open_browser: bool = True) -> None:
+    config = SaxoConfig.from_env(environment=environment)
+    expected_host = urlparse(config.redirect_uri).hostname
+    expected_port = urlparse(config.redirect_uri).port
+    if expected_port != port:
+        raise SystemExit(
+            f"Port mismatch: SAXO_REDIRECT_URI port={expected_port} but CLI port={port}. "
+            f"Set --port {expected_port} or update SAXO_REDIRECT_URI in .env"
+        )
+
+    conn = duckdb.connect(str(DB_PATH))
+    db = SenseiDB(conn)
+    try:
+        client = SaxoClient(db, config=config)
+
+        state = secrets.token_urlsafe(24)
+        auth_url = client.build_authorization_url(state=state)
+
+        result = _CallbackResult()
+        server = HTTPServer((expected_host, port), _make_handler(state, result))
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+
+        print(f"[saxo-oauth-init] environment: {config.environment}")
+        print(f"[saxo-oauth-init] listening on http://{expected_host}:{port}/callback")
+        print(f"[saxo-oauth-init] Open this URL in your browser if it does not open automatically:")
+        print(f"\n  {auth_url}\n")
+        if open_browser:
+            webbrowser.open(auth_url)
+
+        # 5分待機。手動ログインが終わるまで block。
+        if not result.event.wait(timeout=300):
+            server.shutdown()
+            raise SystemExit("[saxo-oauth-init] timeout waiting for callback (5 min)")
+        server.shutdown()
+
+        if result.error:
+            raise SystemExit(f"[saxo-oauth-init] callback error: {result.error}")
+
+        print("[saxo-oauth-init] code received, exchanging for tokens...")
+        client.exchange_code_for_tokens(code=result.code)
+        print(f"[saxo-oauth-init] OK. access + refresh tokens saved to {DB_PATH}")
+    finally:
+        conn.close()
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Saxo OpenAPI 初回認可 CLI")
+    parser.add_argument("--env", choices=["sim", "live"], default=None,
+                        help="環境 (.env の SAXO_ENVIRONMENT を上書き)")
+    parser.add_argument("--port", type=int, default=8080,
+                        help="callback リスナーのポート (default: 8080)")
+    parser.add_argument("--no-browser", action="store_true",
+                        help="ブラウザを自動で開かない")
+    args = parser.parse_args()
+
+    try:
+        run_oauth_init(environment=args.env, port=args.port, open_browser=not args.no_browser)
+    except (SaxoAuthError, ValueError) as e:
+        print(f"[saxo-oauth-init] ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db.py
+++ b/src/db.py
@@ -7,6 +7,8 @@
 - regime_assessments: レジーム判定（入力値スナップショット含む、ADR-009）
 - event_reviews: イベント事後検証
 - skill_executions: スキル実行履歴（Airflow dag_runパターン）
+- trades: 取引履歴
+- auth_tokens: 外部API認証トークン（OAuth access/refresh、ADR-025）
 """
 from __future__ import annotations
 
@@ -182,6 +184,25 @@ class SenseiDB:
             )
         """)
         self.conn.execute("CREATE SEQUENCE IF NOT EXISTS trades_id_seq START 1")
+
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS auth_tokens (
+                id INTEGER PRIMARY KEY,
+                provider VARCHAR NOT NULL,
+                environment VARCHAR NOT NULL,
+                token_type VARCHAR NOT NULL,
+                token_value VARCHAR NOT NULL,
+                acquired_at TIMESTAMPTZ NOT NULL,
+                expires_at TIMESTAMPTZ NOT NULL,
+                acquired_via VARCHAR,
+                refresh_count INTEGER DEFAULT 0,
+                metadata VARCHAR,
+                revoked_at TIMESTAMPTZ,
+                revoke_reason VARCHAR,
+                created_at TIMESTAMP DEFAULT current_timestamp
+            )
+        """)
+        self.conn.execute("CREATE SEQUENCE IF NOT EXISTS auth_tokens_id_seq START 1")
 
     # ── events ──
 
@@ -637,6 +658,76 @@ class SenseiDB:
             "SELECT * FROM trades WHERE exit_date IS NULL ORDER BY entry_date"
         ).fetchdf().to_dict("records")
         return rows
+
+    # ── auth_tokens (ADR-025) ──
+
+    def save_token(
+        self,
+        provider: str,
+        environment: str,
+        token_type: str,
+        token_value: str,
+        expires_at: datetime,
+        *,
+        acquired_via: str = None,
+        refresh_count: int = 0,
+        metadata: str = None,
+    ) -> int:
+        _require_aware(expires_at, "expires_at")
+        token_id = self.conn.execute(
+            "SELECT nextval('auth_tokens_id_seq')"
+        ).fetchone()[0]
+        self.conn.execute(
+            "INSERT INTO auth_tokens "
+            "(id, provider, environment, token_type, token_value, "
+            "acquired_at, expires_at, acquired_via, refresh_count, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [token_id, provider, environment, token_type, token_value,
+             now_jst(), expires_at, acquired_via, refresh_count, metadata],
+        )
+        return token_id
+
+    def get_active_token(
+        self,
+        provider: str,
+        environment: str,
+        token_type: str,
+    ) -> Optional[dict]:
+        """最新の未失効・未revokeなトークンを返す。なければ None。"""
+        row = self.conn.execute(
+            "SELECT id, provider, environment, token_type, token_value, "
+            "acquired_at, expires_at, acquired_via, refresh_count, metadata "
+            "FROM auth_tokens "
+            "WHERE provider = ? AND environment = ? AND token_type = ? "
+            "AND revoked_at IS NULL AND expires_at > ? "
+            "ORDER BY acquired_at DESC LIMIT 1",
+            [provider, environment, token_type, now_jst()],
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "provider": row[1],
+            "environment": row[2],
+            "token_type": row[3],
+            "token_value": row[4],
+            "acquired_at": row[5],
+            "expires_at": row[6],
+            "acquired_via": row[7],
+            "refresh_count": row[8],
+            "metadata": row[9],
+        }
+
+    def revoke_token(self, token_id: int, reason: str = None) -> None:
+        existing = self.conn.execute(
+            "SELECT id FROM auth_tokens WHERE id = ?", [token_id]
+        ).fetchone()
+        if existing is None:
+            raise ValueError(f"Token {token_id} not found")
+        self.conn.execute(
+            "UPDATE auth_tokens SET revoked_at = ?, revoke_reason = ? WHERE id = ?",
+            [now_jst(), reason, token_id],
+        )
 
     # ── self-evaluation ──
 

--- a/src/db.py
+++ b/src/db.py
@@ -203,6 +203,12 @@ class SenseiDB:
             )
         """)
         self.conn.execute("CREATE SEQUENCE IF NOT EXISTS auth_tokens_id_seq START 1")
+        # ADR-025 仕様の partial index は DuckDB 未対応 (NotImplementedException)。
+        # regular composite index で代替: get_active_token の主要 WHERE 句に効く。
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_auth_lookup "
+            "ON auth_tokens(provider, environment, token_type)"
+        )
 
     # ── events ──
 

--- a/src/saxo_client.py
+++ b/src/saxo_client.py
@@ -109,6 +109,14 @@ class SaxoConfig:
         if missing:
             raise ValueError(f"Missing required env vars: {missing}")
 
+        for url_key in (f"SAXO_AUTH_URL_{suffix}", f"SAXO_TOKEN_URL_{suffix}"):
+            url_val = keys[url_key]
+            if not url_val.startswith("https://"):
+                raise ValueError(
+                    f"{url_key} must use https:// scheme (credentials transmitted via Basic Auth); "
+                    f"got {url_val!r}"
+                )
+
         base_url = BASE_URL_SIM if env == "sim" else BASE_URL_LIVE
         return cls(
             app_key=keys[f"SAXO_APP_KEY_{suffix}"],
@@ -163,9 +171,19 @@ class SaxoClient:
         )
         if not resp.ok:
             raise SaxoAuthError(
-                f"Initial token exchange failed: {resp.status_code} {resp.text[:300]}"
+                f"Initial token exchange failed: HTTP {resp.status_code}"
             )
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise SaxoAuthError(
+                f"Token endpoint returned non-JSON response: HTTP {resp.status_code}"
+            ) from exc
+        if "refresh_token" not in data:
+            raise SaxoAuthError(
+                "Token endpoint did not return refresh_token. "
+                "Check OAuth app scope/grant type configuration on Saxo Developer Portal."
+            )
         self._persist_token_response(data, acquired_via="oauth_initial", prev_refresh_count=0)
         logger.info("Saxo OAuth initial tokens persisted (env=%s)", self.config.environment)
         return data
@@ -208,12 +226,22 @@ class SaxoClient:
             timeout=DEFAULT_TIMEOUT_SEC,
         )
         if not resp.ok:
-            self.db.revoke_token(refresh_row["id"], reason=f"refresh_http_{resp.status_code}")
+            # Only revoke on definitive auth failures (invalid_grant / unauthorized).
+            # 5xx and 429 are transient — keep refresh token so caller can retry later.
+            if self._is_definitive_auth_failure(resp):
+                self.db.revoke_token(
+                    refresh_row["id"], reason=f"refresh_http_{resp.status_code}"
+                )
             raise SaxoAuthError(
-                f"Token refresh failed: {resp.status_code} {resp.text[:300]}"
+                f"Token refresh failed: HTTP {resp.status_code}"
             )
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise SaxoAuthError(
+                f"Token refresh returned non-JSON response: HTTP {resp.status_code}"
+            ) from exc
         prev_count = refresh_row["refresh_count"]
         self._persist_token_response(
             data,
@@ -226,6 +254,35 @@ class SaxoClient:
                     self.config.environment, prev_count + 1)
         return data["access_token"]
 
+    @staticmethod
+    def _is_definitive_auth_failure(resp: requests.Response) -> bool:
+        """refresh token を revoke すべき definitive failure か判定。
+
+        判定基準:
+        - HTTP 401: 認証失敗 (token 無効)
+        - HTTP 400 with body containing OAuth error code 'invalid_grant' / 'invalid_request'
+          / 'unauthorized_client' (refresh token 無効化が確定するケース)
+        - その他 4xx は曖昧、保守的に definitive 扱い
+        - 5xx, 429 (rate limit), その他 transient は revoke しない
+
+        See https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+        """
+        if resp.status_code == 429 or resp.status_code >= 500:
+            return False
+        if resp.status_code == 401:
+            return True
+        if resp.status_code == 400:
+            try:
+                error_code = (resp.json() or {}).get("error", "")
+            except ValueError:
+                error_code = ""
+            return error_code in {
+                "invalid_grant", "invalid_request", "unauthorized_client",
+                "unsupported_grant_type",
+            }
+        # その他 4xx は保守的に revoke (network proxy, malformed request 等)
+        return 400 <= resp.status_code < 500
+
     def _persist_token_response(
         self,
         data: dict,
@@ -237,12 +294,30 @@ class SaxoClient:
     ) -> None:
         """token endpoint response から access + refresh を DB 保存。
         rotation が発生していれば旧 refresh を revoke。"""
+        required = ("access_token", "expires_in")
+        missing = [k for k in required if k not in data]
+        if missing:
+            raise SaxoAuthError(
+                f"Token response missing required keys {missing} "
+                f"(present keys: {sorted(data.keys())})"
+            )
+        try:
+            expires_in_sec = int(data["expires_in"])
+        except (TypeError, ValueError) as exc:
+            raise SaxoAuthError(
+                f"Token response has invalid expires_in: {data['expires_in']!r}"
+            ) from exc
+
+        anchor = now_jst()
         access_value = data["access_token"]
-        access_expires = now_jst() + timedelta(seconds=int(data["expires_in"]))
+        access_expires = anchor + timedelta(seconds=expires_in_sec)
         new_refresh_value = data.get("refresh_token")
-        refresh_lifetime = int(data.get("refresh_token_expires_in",
-                                         DEFAULT_REFRESH_TOKEN_LIFETIME_SEC))
-        refresh_expires = now_jst() + timedelta(seconds=refresh_lifetime)
+        try:
+            refresh_lifetime = int(data.get("refresh_token_expires_in",
+                                             DEFAULT_REFRESH_TOKEN_LIFETIME_SEC))
+        except (TypeError, ValueError):
+            refresh_lifetime = DEFAULT_REFRESH_TOKEN_LIFETIME_SEC
+        refresh_expires = anchor + timedelta(seconds=refresh_lifetime)
 
         # access token は常に新規保存
         self.db.save_token(
@@ -316,20 +391,33 @@ class SaxoClient:
         bal = self._api_get(
             f"/port/v1/balances?AccountKey={account_key}&ClientKey={client_key}"
         )
+        required = (
+            "Currency", "SpendingPower", "CashAvailableForTrading", "CashBalance",
+            "TotalValue", "UnrealizedPositionsValue", "TransactionsNotBooked",
+            "OpenPositionsCount", "NetPositionsCount", "NonMarginPositionsValue",
+            "CalculationReliability",
+        )
+        missing = [k for k in required if k not in bal]
+        if missing:
+            raise SaxoAuthError(
+                f"Balance response missing required fields {missing} "
+                f"for account {account_id or account_key}. "
+                "Saxo API may have changed; verify docs/api/saxo/balance-fields.md"
+            )
         return AccountBalance(
             account_id=account_id,
             account_key=account_key,
             currency=bal["Currency"],
-            spending_power=float(bal["SpendingPower"]),
-            cash_available_for_trading=float(bal["CashAvailableForTrading"]),
-            settled_cash_balance=float(bal["CashBalance"]),
-            total_value=float(bal["TotalValue"]),
-            unrealized_pnl=float(bal["UnrealizedPositionsValue"]),
-            transactions_not_booked=float(bal["TransactionsNotBooked"]),
-            open_positions_count=int(bal["OpenPositionsCount"]),
-            net_positions_count=int(bal["NetPositionsCount"]),
-            non_margin_positions_value=float(bal["NonMarginPositionsValue"]),
-            calculation_reliability=bal["CalculationReliability"],
+            spending_power=float(bal["SpendingPower"]),  # see balance-fields.md#spendingpower
+            cash_available_for_trading=float(bal["CashAvailableForTrading"]),  # see #cashavailablefortrading
+            settled_cash_balance=float(bal["CashBalance"]),  # see #cashbalance
+            total_value=float(bal["TotalValue"]),  # see #totalvalue
+            unrealized_pnl=float(bal["UnrealizedPositionsValue"]),  # see #unrealizedpositionsvalue
+            transactions_not_booked=float(bal["TransactionsNotBooked"]),  # see #transactionsnotbooked
+            open_positions_count=int(bal["OpenPositionsCount"]),  # see #openpositionscount
+            net_positions_count=int(bal["NetPositionsCount"]),  # see #netpositionscount
+            non_margin_positions_value=float(bal["NonMarginPositionsValue"]),  # see #nonmarginpositionsvalue
+            calculation_reliability=bal["CalculationReliability"],  # see #calculationreliability
         )
 
     def get_all_account_balances(self) -> list[AccountBalance]:
@@ -366,4 +454,9 @@ class SaxoClient:
                 "Try re-authenticating via scripts/saxo_oauth_init.py"
             )
         resp.raise_for_status()
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise SaxoAuthError(
+                f"Non-JSON response from {path}: HTTP {resp.status_code}"
+            ) from exc

--- a/src/saxo_client.py
+++ b/src/saxo_client.py
@@ -1,0 +1,369 @@
+"""Saxo OpenAPI クライアント (ADR-025)
+
+OAuth 2.0 Authorization Code grant + refresh フロー。
+access token は 20分で失効するため自動 refresh。
+refresh token は rotation するため refresh ごとに DB に新規保存・旧 refresh は revoke。
+
+トークン保管は DuckDB `auth_tokens` テーブル (ADR-025)。
+App Key / Secret は .env (静的config と動的state を分離)。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlencode
+
+import requests
+from dotenv import load_dotenv
+
+from src.db import SenseiDB, now_jst
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+logger = logging.getLogger(__name__)
+
+PROVIDER = "saxo"
+
+# refresh buffer: access token expiry が これより近づいたら refresh する
+ACCESS_TOKEN_REFRESH_BUFFER_SEC = 60
+
+DEFAULT_TIMEOUT_SEC = 10
+
+# Saxo API base URL (REST). 公式: https://www.developer.saxo/openapi/learn/environments
+BASE_URL_LIVE = "https://gateway.saxobank.com/openapi"
+BASE_URL_SIM = "https://gateway.saxobank.com/sim/openapi"
+
+# refresh token expiry が response に含まれない場合のデフォルト (90日、Saxo 仕様の典型値)
+DEFAULT_REFRESH_TOKEN_LIFETIME_SEC = 86400 * 90
+
+
+class SaxoAuthError(Exception):
+    """OAuth 認証フローのエラー"""
+
+
+@dataclass
+class AccountBalance:
+    """口座別の意味的 balance snapshot (ADR-026)。
+
+    raw dict キー access を防ぐためのインタフェース。各フィールドの
+    公式定義は docs/api/saxo/balance-fields.md を参照。
+
+    Attributes:
+        spending_power: 取引可能額 (sizing 判断に使う)。
+            CashAvailableForTrading と通常同値、未決済込み。
+        cash_available_for_trading: 同上 (互換性のため別名)。
+        settled_cash_balance: settled cash のみ。**sizing には使わない** (未決済を
+            含まないため過小評価)。会計表示用途のみ。
+        total_value: NAV (cash + 未実現ポジション評価額)。
+        unrealized_pnl: 含み損益。
+        transactions_not_booked: T+2 未決済額 (debug 用)。
+        open_positions_count: open position 数。
+        net_positions_count: open + settling closed の合計。
+        non_margin_positions_value: cash instrument の合計評価額。
+        calculation_reliability: "Ok" 以外は調査必要。
+    """
+    account_id: str
+    account_key: str
+    currency: str
+    spending_power: float
+    cash_available_for_trading: float
+    settled_cash_balance: float
+    total_value: float
+    unrealized_pnl: float
+    transactions_not_booked: float
+    open_positions_count: int
+    net_positions_count: int
+    non_margin_positions_value: float
+    calculation_reliability: str
+
+
+@dataclass
+class SaxoConfig:
+    app_key: str
+    app_secret: str
+    auth_url: str
+    token_url: str
+    redirect_uri: str
+    environment: str  # 'sim' | 'live'
+    base_url: str
+
+    @classmethod
+    def from_env(cls, environment: Optional[str] = None) -> SaxoConfig:
+        env = (environment or os.environ.get("SAXO_ENVIRONMENT", "live")).lower()
+        if env not in {"sim", "live"}:
+            raise ValueError(f"SAXO_ENVIRONMENT must be 'sim' or 'live', got '{env}'")
+
+        suffix = env.upper()
+        keys = {
+            f"SAXO_APP_KEY_{suffix}": os.environ.get(f"SAXO_APP_KEY_{suffix}"),
+            f"SAXO_APP_SECRET_{suffix}": os.environ.get(f"SAXO_APP_SECRET_{suffix}"),
+            f"SAXO_AUTH_URL_{suffix}": os.environ.get(f"SAXO_AUTH_URL_{suffix}"),
+            f"SAXO_TOKEN_URL_{suffix}": os.environ.get(f"SAXO_TOKEN_URL_{suffix}"),
+            "SAXO_REDIRECT_URI": os.environ.get("SAXO_REDIRECT_URI"),
+        }
+        missing = [name for name, val in keys.items() if not val]
+        if missing:
+            raise ValueError(f"Missing required env vars: {missing}")
+
+        base_url = BASE_URL_SIM if env == "sim" else BASE_URL_LIVE
+        return cls(
+            app_key=keys[f"SAXO_APP_KEY_{suffix}"],
+            app_secret=keys[f"SAXO_APP_SECRET_{suffix}"],
+            auth_url=keys[f"SAXO_AUTH_URL_{suffix}"],
+            token_url=keys[f"SAXO_TOKEN_URL_{suffix}"],
+            redirect_uri=keys["SAXO_REDIRECT_URI"],
+            environment=env,
+            base_url=base_url,
+        )
+
+
+class SaxoClient:
+    """Saxo OpenAPI 用 OAuth クライアント + Portfolio API ラッパー
+
+    Usage:
+        db = SenseiDB(conn)
+        client = SaxoClient(db)
+        balances = client.get_balances()
+        positions = client.get_positions()
+    """
+
+    def __init__(self, db: SenseiDB, config: Optional[SaxoConfig] = None,
+                 session: Optional[requests.Session] = None):
+        self.db = db
+        self.config = config or SaxoConfig.from_env()
+        self._session = session or requests.Session()
+
+    # ── OAuth flow ──
+
+    def build_authorization_url(self, state: str) -> str:
+        """初回認可で使う URL を生成。ブラウザで開いてユーザにログインしてもらう。"""
+        params = {
+            "response_type": "code",
+            "client_id": self.config.app_key,
+            "redirect_uri": self.config.redirect_uri,
+            "state": state,
+        }
+        return f"{self.config.auth_url}?{urlencode(params)}"
+
+    def exchange_code_for_tokens(self, code: str) -> dict:
+        """OAuth callback で受け取った code を access+refresh token に交換し DB 保存"""
+        resp = self._session.post(
+            self.config.token_url,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.config.redirect_uri,
+            },
+            auth=(self.config.app_key, self.config.app_secret),
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+        if not resp.ok:
+            raise SaxoAuthError(
+                f"Initial token exchange failed: {resp.status_code} {resp.text[:300]}"
+            )
+        data = resp.json()
+        self._persist_token_response(data, acquired_via="oauth_initial", prev_refresh_count=0)
+        logger.info("Saxo OAuth initial tokens persisted (env=%s)", self.config.environment)
+        return data
+
+    def get_access_token(self) -> str:
+        """有効な access token を返す。失効間際なら refresh。"""
+        token = self.db.get_active_token(
+            provider=PROVIDER,
+            environment=self.config.environment,
+            token_type="access",
+        )
+        if token and self._token_has_buffer(token):
+            return token["token_value"]
+        return self._refresh_access_token()
+
+    def _token_has_buffer(self, token: dict) -> bool:
+        remaining = token["expires_at"] - now_jst()
+        return remaining > timedelta(seconds=ACCESS_TOKEN_REFRESH_BUFFER_SEC)
+
+    def _refresh_access_token(self) -> str:
+        refresh_row = self.db.get_active_token(
+            provider=PROVIDER,
+            environment=self.config.environment,
+            token_type="refresh",
+        )
+        if refresh_row is None:
+            raise SaxoAuthError(
+                "No valid refresh token. "
+                "Run `python scripts/saxo_oauth_init.py` to re-authenticate."
+            )
+
+        resp = self._session.post(
+            self.config.token_url,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_row["token_value"],
+                "redirect_uri": self.config.redirect_uri,
+            },
+            auth=(self.config.app_key, self.config.app_secret),
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+        if not resp.ok:
+            self.db.revoke_token(refresh_row["id"], reason=f"refresh_http_{resp.status_code}")
+            raise SaxoAuthError(
+                f"Token refresh failed: {resp.status_code} {resp.text[:300]}"
+            )
+
+        data = resp.json()
+        prev_count = refresh_row["refresh_count"]
+        self._persist_token_response(
+            data,
+            acquired_via="oauth_refresh",
+            prev_refresh_count=prev_count,
+            old_refresh_id=refresh_row["id"],
+            old_refresh_value=refresh_row["token_value"],
+        )
+        logger.info("Saxo access token refreshed (env=%s, count=%d)",
+                    self.config.environment, prev_count + 1)
+        return data["access_token"]
+
+    def _persist_token_response(
+        self,
+        data: dict,
+        *,
+        acquired_via: str,
+        prev_refresh_count: int,
+        old_refresh_id: Optional[int] = None,
+        old_refresh_value: Optional[str] = None,
+    ) -> None:
+        """token endpoint response から access + refresh を DB 保存。
+        rotation が発生していれば旧 refresh を revoke。"""
+        access_value = data["access_token"]
+        access_expires = now_jst() + timedelta(seconds=int(data["expires_in"]))
+        new_refresh_value = data.get("refresh_token")
+        refresh_lifetime = int(data.get("refresh_token_expires_in",
+                                         DEFAULT_REFRESH_TOKEN_LIFETIME_SEC))
+        refresh_expires = now_jst() + timedelta(seconds=refresh_lifetime)
+
+        # access token は常に新規保存
+        self.db.save_token(
+            provider=PROVIDER,
+            environment=self.config.environment,
+            token_type="access",
+            token_value=access_value,
+            expires_at=access_expires,
+            acquired_via=acquired_via,
+            refresh_count=prev_refresh_count + (1 if acquired_via == "oauth_refresh" else 0),
+            metadata=json.dumps({"response_keys": sorted(data.keys())}),
+        )
+
+        # refresh token: rotation が発生していれば保存 + 旧 revoke
+        if new_refresh_value and new_refresh_value != old_refresh_value:
+            self.db.save_token(
+                provider=PROVIDER,
+                environment=self.config.environment,
+                token_type="refresh",
+                token_value=new_refresh_value,
+                expires_at=refresh_expires,
+                acquired_via=acquired_via,
+                refresh_count=prev_refresh_count + (1 if acquired_via == "oauth_refresh" else 0),
+                metadata=json.dumps({"response_keys": sorted(data.keys())}),
+            )
+            if old_refresh_id is not None:
+                self.db.revoke_token(old_refresh_id, reason="rotated_on_refresh")
+
+    # ── Portfolio API (read-only) ──
+
+    def get_balances(self) -> dict:
+        """aggregated balance (全 sub-account 合算、base currency 換算)。raw dict 返却。
+
+        ⚠️ **sizing 判断には使わない**。
+          - 口座別の取引余力は `get_account_balance()` 経由で取得すること。
+          - dict キー直接 access (`["CashBalance"]` 等) も禁止 (ADR-026)。
+
+        この method は schema 確認・field 探索など調査用途のみ。
+
+        See docs/api/saxo/endpoints.md#2-get-portv1balancesme
+        """
+        return self._api_get("/port/v1/balances/me")
+
+    def get_positions(self) -> list[dict]:
+        """open positions のリストを返す (Data 配列、raw dict)。
+
+        See docs/api/saxo/endpoints.md#4-get-portv1positionsme
+        """
+        return self._api_get("/port/v1/positions/me").get("Data", [])
+
+    def get_accounts(self) -> list[dict]:
+        """全 sub-account 一覧 (Data 配列、raw dict)。
+
+        See docs/api/saxo/endpoints.md#1-get-portv1accountsme
+        """
+        return self._api_get("/port/v1/accounts/me").get("Data", [])
+
+    def get_account_balance(self, account_key: str, client_key: str,
+                            account_id: str = "") -> AccountBalance:
+        """口座別の意味的 balance snapshot を返す (推奨インタフェース)。
+
+        sizing 判断 (例: SOXL 何株買えるか) は `result.spending_power` を使うこと。
+        `result.settled_cash_balance` は会計表示用、sizing には使わない (未決済を含まない)。
+
+        ADR-026 に基づき raw dict 露出を防ぐ。新規 field が必要な場合は
+        `AccountBalance` dataclass を拡張し、`docs/api/saxo/balance-fields.md` に
+        該当 field の公式定義を追記すること (citation 必須)。
+
+        See docs/api/saxo/balance-fields.md
+        """
+        bal = self._api_get(
+            f"/port/v1/balances?AccountKey={account_key}&ClientKey={client_key}"
+        )
+        return AccountBalance(
+            account_id=account_id,
+            account_key=account_key,
+            currency=bal["Currency"],
+            spending_power=float(bal["SpendingPower"]),
+            cash_available_for_trading=float(bal["CashAvailableForTrading"]),
+            settled_cash_balance=float(bal["CashBalance"]),
+            total_value=float(bal["TotalValue"]),
+            unrealized_pnl=float(bal["UnrealizedPositionsValue"]),
+            transactions_not_booked=float(bal["TransactionsNotBooked"]),
+            open_positions_count=int(bal["OpenPositionsCount"]),
+            net_positions_count=int(bal["NetPositionsCount"]),
+            non_margin_positions_value=float(bal["NonMarginPositionsValue"]),
+            calculation_reliability=bal["CalculationReliability"],
+        )
+
+    def get_all_account_balances(self) -> list[AccountBalance]:
+        """全 active sub-account の意味的 balance を取得。
+
+        AccountBalance.account_id で各口座を識別できる (P120136 / T126816 等)。
+
+        See docs/api/saxo/balance-fields.md
+        """
+        accounts = self.get_accounts()
+        results: list[AccountBalance] = []
+        for a in accounts:
+            if not a.get("Active"):
+                continue
+            balance = self.get_account_balance(
+                account_key=a["AccountKey"],
+                client_key=a["ClientKey"],
+                account_id=a["AccountId"],
+            )
+            results.append(balance)
+        return results
+
+    def _api_get(self, path: str) -> dict:
+        token = self.get_access_token()
+        url = self.config.base_url + path
+        resp = self._session.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=DEFAULT_TIMEOUT_SEC,
+        )
+        if resp.status_code == 401:
+            raise SaxoAuthError(
+                f"401 from {path}. Token may be invalid or revoked server-side. "
+                "Try re-authenticating via scripts/saxo_oauth_init.py"
+            )
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -30,7 +30,10 @@ class TestSchema:
             "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
         ).fetchall()
         names = {t[0] for t in tables}
-        assert names >= {"events", "predictions", "knowledge", "regime_assessments", "event_reviews", "skill_executions"}
+        assert names >= {
+            "events", "predictions", "knowledge", "regime_assessments",
+            "event_reviews", "skill_executions", "trades", "auth_tokens",
+        }
         assert "market_observations" not in names  # ADR-009: 廃止
 
     def test_regime_assessments_has_snapshot_columns(self, db):

--- a/tests/test_db_auth_tokens.py
+++ b/tests/test_db_auth_tokens.py
@@ -1,0 +1,193 @@
+"""SenseiDB auth_tokens テーブル ユニットテスト (ADR-025)"""
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.db import JST, SenseiDB, now_jst
+
+
+@pytest.fixture
+def db(db_conn):
+    return SenseiDB(db_conn)
+
+
+def _future(seconds: int) -> datetime:
+    return now_jst() + timedelta(seconds=seconds)
+
+
+def _past(seconds: int) -> datetime:
+    return now_jst() - timedelta(seconds=seconds)
+
+
+class TestAuthTokensSchema:
+    def test_table_created(self, db):
+        tables = db.conn.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'main' AND table_name = 'auth_tokens'"
+        ).fetchall()
+        assert len(tables) == 1
+
+    def test_required_columns_present(self, db):
+        cols = {
+            row[0]
+            for row in db.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'auth_tokens' AND table_schema = 'main'"
+            ).fetchall()
+        }
+        required = {
+            "id", "provider", "environment", "token_type", "token_value",
+            "acquired_at", "expires_at", "acquired_via", "refresh_count",
+            "metadata", "revoked_at", "revoke_reason", "created_at",
+        }
+        assert required <= cols
+
+
+class TestSaveToken:
+    def test_save_returns_id(self, db):
+        tid = db.save_token(
+            provider="saxo",
+            environment="live",
+            token_type="access",
+            token_value="access_xyz",
+            expires_at=_future(1200),
+            acquired_via="oauth_initial",
+        )
+        assert isinstance(tid, int)
+        assert tid >= 1
+
+    def test_save_persists_all_fields(self, db):
+        expires = _future(1200)
+        tid = db.save_token(
+            provider="saxo",
+            environment="live",
+            token_type="refresh",
+            token_value="refresh_abc",
+            expires_at=expires,
+            acquired_via="oauth_initial",
+            refresh_count=3,
+            metadata='{"scope":"read"}',
+        )
+        row = db.conn.execute(
+            "SELECT provider, environment, token_type, token_value, "
+            "acquired_via, refresh_count, metadata "
+            "FROM auth_tokens WHERE id = ?",
+            [tid],
+        ).fetchone()
+        assert row == ("saxo", "live", "refresh", "refresh_abc",
+                       "oauth_initial", 3, '{"scope":"read"}')
+
+    def test_save_records_acquired_at_as_now(self, db):
+        before = now_jst()
+        tid = db.save_token(
+            provider="saxo", environment="live", token_type="access",
+            token_value="x", expires_at=_future(1200),
+        )
+        after = now_jst()
+        acquired_at = db.conn.execute(
+            "SELECT acquired_at FROM auth_tokens WHERE id = ?", [tid]
+        ).fetchone()[0]
+        assert before <= acquired_at <= after
+
+    def test_save_naive_expires_at_raises(self, db):
+        with pytest.raises(ValueError, match="timezone-aware"):
+            db.save_token(
+                provider="saxo", environment="live", token_type="access",
+                token_value="x",
+                expires_at=datetime(2030, 1, 1, 0, 0),
+            )
+
+    def test_save_multiple_tokens_different_ids(self, db):
+        t1 = db.save_token(
+            provider="saxo", environment="live", token_type="access",
+            token_value="a", expires_at=_future(1200),
+        )
+        t2 = db.save_token(
+            provider="saxo", environment="live", token_type="access",
+            token_value="b", expires_at=_future(1200),
+        )
+        assert t1 != t2
+
+
+class TestGetActiveToken:
+    def test_returns_none_when_no_tokens(self, db):
+        result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert result is None
+
+    def test_returns_latest_unexpired_unrevoked(self, db):
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="older", expires_at=_future(1200))
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="newer", expires_at=_future(1200))
+        result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert result is not None
+        assert result["token_value"] == "newer"
+
+    def test_excludes_expired(self, db):
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="expired", expires_at=_past(60))
+        result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert result is None
+
+    def test_prefers_unexpired_even_if_older(self, db):
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="valid", expires_at=_future(1200))
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="expired_recent", expires_at=_past(60))
+        result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert result["token_value"] == "valid"
+
+    def test_excludes_revoked(self, db):
+        tid = db.save_token(provider="saxo", environment="live", token_type="access",
+                            token_value="revoked", expires_at=_future(1200))
+        db.revoke_token(tid, reason="manual_revoke")
+        result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert result is None
+
+    def test_environment_isolation(self, db):
+        db.save_token(provider="saxo", environment="sim", token_type="access",
+                      token_value="sim_token", expires_at=_future(1200))
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="live_token", expires_at=_future(1200))
+        sim_result = db.get_active_token(provider="saxo", environment="sim", token_type="access")
+        live_result = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        assert sim_result["token_value"] == "sim_token"
+        assert live_result["token_value"] == "live_token"
+
+    def test_token_type_isolation(self, db):
+        db.save_token(provider="saxo", environment="live", token_type="access",
+                      token_value="access_v", expires_at=_future(1200))
+        db.save_token(provider="saxo", environment="live", token_type="refresh",
+                      token_value="refresh_v", expires_at=_future(60 * 60 * 24 * 60))
+        access = db.get_active_token(provider="saxo", environment="live", token_type="access")
+        refresh = db.get_active_token(provider="saxo", environment="live", token_type="refresh")
+        assert access["token_value"] == "access_v"
+        assert refresh["token_value"] == "refresh_v"
+
+
+class TestRevokeToken:
+    def test_revoke_sets_revoked_at_and_reason(self, db):
+        tid = db.save_token(provider="saxo", environment="live", token_type="access",
+                            token_value="x", expires_at=_future(1200))
+        before = now_jst()
+        db.revoke_token(tid, reason="oauth_refresh_failure")
+        after = now_jst()
+        row = db.conn.execute(
+            "SELECT revoked_at, revoke_reason FROM auth_tokens WHERE id = ?",
+            [tid],
+        ).fetchone()
+        assert row[0] is not None
+        assert before <= row[0] <= after
+        assert row[1] == "oauth_refresh_failure"
+
+    def test_revoke_nonexistent_raises(self, db):
+        with pytest.raises(ValueError, match="not found"):
+            db.revoke_token(99999, reason="x")
+
+    def test_revoke_preserves_audit_record(self, db):
+        """ADR-025: append-only。revoked token は DELETE せず audit保持"""
+        tid = db.save_token(provider="saxo", environment="live", token_type="access",
+                            token_value="x", expires_at=_future(1200))
+        db.revoke_token(tid, reason="x")
+        row = db.conn.execute("SELECT id FROM auth_tokens WHERE id = ?", [tid]).fetchone()
+        assert row is not None

--- a/tests/test_saxo_client.py
+++ b/tests/test_saxo_client.py
@@ -95,10 +95,30 @@ class TestSaxoConfig:
         monkeypatch.setenv("SAXO_ENVIRONMENT", "live")
         monkeypatch.delenv("SAXO_APP_KEY_LIVE", raising=False)
         monkeypatch.setenv("SAXO_APP_SECRET_LIVE", "s")
-        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "u")
-        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "u")
-        monkeypatch.setenv("SAXO_REDIRECT_URI", "u")
+        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "https://example.com/a")
+        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "https://example.com/t")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "http://localhost:8080/callback")
         with pytest.raises(ValueError, match="SAXO_APP_KEY_LIVE"):
+            SaxoConfig.from_env()
+
+    def test_from_env_http_auth_url_rejected(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "live")
+        monkeypatch.setenv("SAXO_APP_KEY_LIVE", "k")
+        monkeypatch.setenv("SAXO_APP_SECRET_LIVE", "s")
+        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "http://insecure.example/authorize")
+        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "https://example.com/token")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "http://localhost:8080/callback")
+        with pytest.raises(ValueError, match="must use https://"):
+            SaxoConfig.from_env()
+
+    def test_from_env_http_token_url_rejected(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "live")
+        monkeypatch.setenv("SAXO_APP_KEY_LIVE", "k")
+        monkeypatch.setenv("SAXO_APP_SECRET_LIVE", "s")
+        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "https://example.com/a")
+        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "http://insecure.example/token")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "http://localhost:8080/callback")
+        with pytest.raises(ValueError, match="must use https://"):
             SaxoConfig.from_env()
 
 
@@ -131,6 +151,35 @@ class TestExchangeCodeForTokens:
         mock_session.post.return_value = _mock_response(400, text="invalid_grant")
         with pytest.raises(SaxoAuthError, match="Initial token exchange failed"):
             client.exchange_code_for_tokens(code="bad_code")
+
+    def test_missing_refresh_token_raises(self, client, mock_session):
+        """initial exchange で refresh_token が response にない場合は明示 raise"""
+        mock_session.post.return_value = _mock_response(200, {
+            "access_token": "AT1",
+            "expires_in": 1200,
+        })
+        with pytest.raises(SaxoAuthError, match="did not return refresh_token"):
+            client.exchange_code_for_tokens(code="callback_code")
+
+    def test_missing_access_token_raises(self, client, mock_session):
+        """access_token 欠落も明示 raise (cryptic KeyError 防止)"""
+        mock_session.post.return_value = _mock_response(200, {
+            "refresh_token": "RT1",
+            "expires_in": 1200,
+        })
+        with pytest.raises(SaxoAuthError, match="missing required keys"):
+            client.exchange_code_for_tokens(code="callback_code")
+
+    def test_non_json_response_raises(self, client, mock_session):
+        """非JSON 200 response も明示 raise"""
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.ok = True
+        resp.text = "<html>not json</html>"
+        resp.json.side_effect = ValueError("Expecting value")
+        mock_session.post.return_value = resp
+        with pytest.raises(SaxoAuthError, match="non-JSON response"):
+            client.exchange_code_for_tokens(code="callback_code")
 
 
 class TestGetAccessToken:
@@ -187,11 +236,66 @@ class TestGetAccessToken:
         mock_session.post.return_value = _mock_response(401, text="invalid refresh")
         with pytest.raises(SaxoAuthError, match="Token refresh failed"):
             client.get_access_token()
-        # Verify revoked
         row = db.conn.execute(
             "SELECT revoke_reason FROM auth_tokens WHERE id = ?", [rt_id]
         ).fetchone()
         assert row[0] == "refresh_http_401"
+
+    def test_refresh_5xx_does_NOT_revoke_token(self, client, db, mock_session):
+        """transient 5xx で refresh token を revoke しない (lockout 防止)"""
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_alive", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(503, text="Service Unavailable")
+        with pytest.raises(SaxoAuthError, match="Token refresh failed"):
+            client.get_access_token()
+        row = db.conn.execute(
+            "SELECT revoked_at FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] is None, "5xx should NOT revoke refresh token"
+
+    def test_refresh_429_does_NOT_revoke_token(self, client, db, mock_session):
+        """rate limit (429) も transient、revoke しない"""
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_alive", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(429, text="Too Many Requests")
+        with pytest.raises(SaxoAuthError):
+            client.get_access_token()
+        row = db.conn.execute(
+            "SELECT revoked_at FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] is None
+
+    def test_refresh_400_invalid_grant_revokes_token(self, client, db, mock_session):
+        """400 invalid_grant は definitive failure、revoke する"""
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_bad", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(400, {"error": "invalid_grant"})
+        with pytest.raises(SaxoAuthError):
+            client.get_access_token()
+        row = db.conn.execute(
+            "SELECT revoke_reason FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] == "refresh_http_400"
+
+    def test_refresh_400_other_error_does_NOT_revoke_token(self, client, db, mock_session):
+        """400 で error が invalid_grant 以外なら revoke しない (保守的)"""
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_alive", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(400, {"error": "temporarily_unavailable"})
+        with pytest.raises(SaxoAuthError):
+            client.get_access_token()
+        row = db.conn.execute(
+            "SELECT revoked_at FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] is None
 
     def test_refresh_rotates_old_refresh_token(self, client, db, mock_session):
         rt_id = db.save_token(
@@ -305,6 +409,16 @@ class TestSemanticAccessors:
         url = mock_session.get.call_args[0][0]
         assert "AccountKey=AK1" in url
         assert "ClientKey=CK1" in url
+
+    def test_get_account_balance_missing_field_raises(self, client, db, mock_session):
+        """balance response から required field が欠けたら SaxoAuthError"""
+        self._setup_valid_access(db)
+        # SpendingPower を意図的に省略
+        incomplete = self._balance_response()
+        del incomplete["SpendingPower"]
+        mock_session.get.return_value = _mock_response(200, incomplete)
+        with pytest.raises(SaxoAuthError, match="missing required fields"):
+            client.get_account_balance(account_key="AK", client_key="CK")
 
     def test_get_all_account_balances_iterates_active_only(
             self, client, db, mock_session):

--- a/tests/test_saxo_client.py
+++ b/tests/test_saxo_client.py
@@ -1,0 +1,330 @@
+"""SaxoClient ユニットテスト (ADR-025)
+
+HTTP は requests-mock ライクに pytest-mock の Mock セッションで差し替える。
+DB は in-memory DuckDB (conftest.db_conn fixture)。
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from src.db import SenseiDB, now_jst
+from src.saxo_client import (
+    BASE_URL_LIVE,
+    BASE_URL_SIM,
+    PROVIDER,
+    AccountBalance,
+    SaxoAuthError,
+    SaxoClient,
+    SaxoConfig,
+)
+
+
+@pytest.fixture
+def db(db_conn):
+    return SenseiDB(db_conn)
+
+
+@pytest.fixture
+def config():
+    return SaxoConfig(
+        app_key="test_key",
+        app_secret="test_secret",
+        auth_url="https://live.logonvalidation.net/authorize",
+        token_url="https://live.logonvalidation.net/token",
+        redirect_uri="http://localhost:8080/callback",
+        environment="live",
+        base_url=BASE_URL_LIVE,
+    )
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock(spec=requests.Session)
+
+
+@pytest.fixture
+def client(db, config, mock_session):
+    return SaxoClient(db, config=config, session=mock_session)
+
+
+def _mock_response(status: int, json_body: dict = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.ok = 200 <= status < 300
+    resp.text = text
+    resp.json.return_value = json_body or {}
+    if not resp.ok:
+        resp.raise_for_status.side_effect = requests.HTTPError(f"{status}")
+    return resp
+
+
+class TestSaxoConfig:
+    def test_from_env_live(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "live")
+        monkeypatch.setenv("SAXO_APP_KEY_LIVE", "k")
+        monkeypatch.setenv("SAXO_APP_SECRET_LIVE", "s")
+        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "https://live.logonvalidation.net/authorize")
+        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "https://live.logonvalidation.net/token")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "http://localhost:8080/callback")
+        cfg = SaxoConfig.from_env()
+        assert cfg.environment == "live"
+        assert cfg.base_url == BASE_URL_LIVE
+        assert cfg.app_key == "k"
+
+    def test_from_env_sim(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "sim")
+        monkeypatch.setenv("SAXO_APP_KEY_SIM", "k")
+        monkeypatch.setenv("SAXO_APP_SECRET_SIM", "s")
+        monkeypatch.setenv("SAXO_AUTH_URL_SIM", "https://sim.logonvalidation.net/authorize")
+        monkeypatch.setenv("SAXO_TOKEN_URL_SIM", "https://sim.logonvalidation.net/token")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "http://localhost:8080/callback")
+        cfg = SaxoConfig.from_env()
+        assert cfg.environment == "sim"
+        assert cfg.base_url == BASE_URL_SIM
+
+    def test_from_env_invalid_environment_raises(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "wrong")
+        with pytest.raises(ValueError, match="must be 'sim' or 'live'"):
+            SaxoConfig.from_env()
+
+    def test_from_env_missing_var_raises(self, monkeypatch):
+        monkeypatch.setenv("SAXO_ENVIRONMENT", "live")
+        monkeypatch.delenv("SAXO_APP_KEY_LIVE", raising=False)
+        monkeypatch.setenv("SAXO_APP_SECRET_LIVE", "s")
+        monkeypatch.setenv("SAXO_AUTH_URL_LIVE", "u")
+        monkeypatch.setenv("SAXO_TOKEN_URL_LIVE", "u")
+        monkeypatch.setenv("SAXO_REDIRECT_URI", "u")
+        with pytest.raises(ValueError, match="SAXO_APP_KEY_LIVE"):
+            SaxoConfig.from_env()
+
+
+class TestBuildAuthorizationUrl:
+    def test_includes_required_params(self, client):
+        url = client.build_authorization_url(state="rnd123")
+        assert "response_type=code" in url
+        assert "client_id=test_key" in url
+        assert "redirect_uri=http" in url
+        assert "state=rnd123" in url
+
+
+class TestExchangeCodeForTokens:
+    def test_persists_access_and_refresh(self, client, db, mock_session):
+        mock_session.post.return_value = _mock_response(200, {
+            "access_token": "AT1",
+            "refresh_token": "RT1",
+            "expires_in": 1200,
+            "refresh_token_expires_in": 60 * 60 * 24 * 30,
+        })
+        client.exchange_code_for_tokens(code="callback_code")
+
+        access = db.get_active_token(provider=PROVIDER, environment="live", token_type="access")
+        refresh = db.get_active_token(provider=PROVIDER, environment="live", token_type="refresh")
+        assert access["token_value"] == "AT1"
+        assert refresh["token_value"] == "RT1"
+        assert access["acquired_via"] == "oauth_initial"
+
+    def test_http_error_raises_auth_error(self, client, mock_session):
+        mock_session.post.return_value = _mock_response(400, text="invalid_grant")
+        with pytest.raises(SaxoAuthError, match="Initial token exchange failed"):
+            client.exchange_code_for_tokens(code="bad_code")
+
+
+class TestGetAccessToken:
+    def test_returns_cached_if_buffer_ok(self, client, db, mock_session):
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="access",
+            token_value="cached_AT", expires_at=now_jst() + timedelta(seconds=600),
+        )
+        result = client.get_access_token()
+        assert result == "cached_AT"
+        mock_session.post.assert_not_called()
+
+    def test_refreshes_when_no_access_token(self, client, db, mock_session):
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_old", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(200, {
+            "access_token": "AT_new",
+            "refresh_token": "RT_new",
+            "expires_in": 1200,
+        })
+        result = client.get_access_token()
+        assert result == "AT_new"
+        mock_session.post.assert_called_once()
+
+    def test_refreshes_when_buffer_too_small(self, client, db, mock_session):
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="access",
+            token_value="AT_dying", expires_at=now_jst() + timedelta(seconds=10),
+        )
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_x", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(200, {
+            "access_token": "AT_refreshed",
+            "refresh_token": "RT_new",
+            "expires_in": 1200,
+        })
+        result = client.get_access_token()
+        assert result == "AT_refreshed"
+
+    def test_raises_when_no_refresh_token(self, client, mock_session):
+        with pytest.raises(SaxoAuthError, match="No valid refresh token"):
+            client.get_access_token()
+        mock_session.post.assert_not_called()
+
+    def test_refresh_failure_revokes_refresh_token(self, client, db, mock_session):
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_bad", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(401, text="invalid refresh")
+        with pytest.raises(SaxoAuthError, match="Token refresh failed"):
+            client.get_access_token()
+        # Verify revoked
+        row = db.conn.execute(
+            "SELECT revoke_reason FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] == "refresh_http_401"
+
+    def test_refresh_rotates_old_refresh_token(self, client, db, mock_session):
+        rt_id = db.save_token(
+            provider=PROVIDER, environment="live", token_type="refresh",
+            token_value="RT_old", expires_at=now_jst() + timedelta(days=30),
+        )
+        mock_session.post.return_value = _mock_response(200, {
+            "access_token": "AT_new",
+            "refresh_token": "RT_NEW_ROTATED",
+            "expires_in": 1200,
+        })
+        client.get_access_token()
+        # 旧 refresh は revoked
+        row = db.conn.execute(
+            "SELECT revoke_reason FROM auth_tokens WHERE id = ?", [rt_id]
+        ).fetchone()
+        assert row[0] == "rotated_on_refresh"
+        # 新 refresh は active
+        new_refresh = db.get_active_token(
+            provider=PROVIDER, environment="live", token_type="refresh"
+        )
+        assert new_refresh["token_value"] == "RT_NEW_ROTATED"
+
+
+class TestPortfolioApi:
+    def _setup_valid_access(self, db):
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="access",
+            token_value="AT_valid", expires_at=now_jst() + timedelta(seconds=1200),
+        )
+
+    def test_get_balances_calls_correct_endpoint(self, client, db, mock_session):
+        self._setup_valid_access(db)
+        mock_session.get.return_value = _mock_response(200, {"CashBalance": 21901})
+        result = client.get_balances()
+        assert result == {"CashBalance": 21901}
+        call_args = mock_session.get.call_args
+        assert call_args[0][0].endswith("/port/v1/balances/me")
+        assert call_args.kwargs["headers"]["Authorization"] == "Bearer AT_valid"
+
+    def test_get_positions_returns_data_array(self, client, db, mock_session):
+        self._setup_valid_access(db)
+        mock_session.get.return_value = _mock_response(200, {
+            "Data": [{"PositionId": "1", "Quantity": 1}],
+        })
+        result = client.get_positions()
+        assert result == [{"PositionId": "1", "Quantity": 1}]
+
+    def test_401_raises_auth_error(self, client, db, mock_session):
+        self._setup_valid_access(db)
+        mock_session.get.return_value = _mock_response(401, text="unauthorized")
+        with pytest.raises(SaxoAuthError, match="401 from"):
+            client.get_balances()
+
+
+class TestSemanticAccessors:
+    """ADR-026: raw dict 露出を防ぐ意味的アクセサ"""
+
+    @staticmethod
+    def _balance_response(spending=103099.0, cash=15216.61, settled=15216.61,
+                          total=103099.0, tnb=87882.39):
+        return {
+            "CalculationReliability": "Ok",
+            "Currency": "JPY",
+            "SpendingPower": spending,
+            "CashAvailableForTrading": cash if cash != 15216.61 else spending,
+            "CashBalance": settled,
+            "TotalValue": total,
+            "UnrealizedPositionsValue": 0.0,
+            "TransactionsNotBooked": tnb,
+            "OpenPositionsCount": 0,
+            "NetPositionsCount": 1,
+            "NonMarginPositionsValue": 0.0,
+        }
+
+    def _setup_valid_access(self, db):
+        db.save_token(
+            provider=PROVIDER, environment="live", token_type="access",
+            token_value="AT_valid", expires_at=now_jst() + timedelta(seconds=1200),
+        )
+
+    def test_get_account_balance_returns_dataclass(self, client, db, mock_session):
+        self._setup_valid_access(db)
+        mock_session.get.return_value = _mock_response(200, self._balance_response())
+        bal = client.get_account_balance(
+            account_key="AK", client_key="CK", account_id="77800/T126816",
+        )
+        assert isinstance(bal, AccountBalance)
+        assert bal.account_id == "77800/T126816"
+        assert bal.account_key == "AK"
+        assert bal.spending_power == 103099.0
+        assert bal.settled_cash_balance == 15216.61
+        assert bal.transactions_not_booked == 87882.39
+
+    def test_get_account_balance_distinguishes_spending_vs_settled(
+            self, client, db, mock_session):
+        """T126816 ケース: spending_power と settled が大きく乖離する"""
+        self._setup_valid_access(db)
+        resp = self._balance_response(spending=103099.0, settled=15216.61)
+        mock_session.get.return_value = _mock_response(200, resp)
+        bal = client.get_account_balance(account_key="AK", client_key="CK")
+        # この差を発見できれば 2026-05-26 の誤りは再発しない
+        assert bal.spending_power > bal.settled_cash_balance
+        assert bal.spending_power - bal.settled_cash_balance == pytest.approx(87882.39)
+
+    def test_get_account_balance_calls_per_account_endpoint(
+            self, client, db, mock_session):
+        self._setup_valid_access(db)
+        mock_session.get.return_value = _mock_response(200, self._balance_response())
+        client.get_account_balance(account_key="AK1", client_key="CK1")
+        url = mock_session.get.call_args[0][0]
+        assert "AccountKey=AK1" in url
+        assert "ClientKey=CK1" in url
+
+    def test_get_all_account_balances_iterates_active_only(
+            self, client, db, mock_session):
+        self._setup_valid_access(db)
+
+        def _side_effect(url, headers=None, timeout=None):
+            if "accounts" in url:
+                return _mock_response(200, {
+                    "Data": [
+                        {"AccountId": "77800/P120136", "AccountKey": "K1",
+                         "ClientKey": "C1", "Currency": "JPY", "Active": True},
+                        {"AccountId": "77800/N122798", "AccountKey": "K2",
+                         "ClientKey": "C2", "Currency": "USD", "Active": False},
+                        {"AccountId": "77800/T126816", "AccountKey": "K3",
+                         "ClientKey": "C3", "Currency": "JPY", "Active": True},
+                    ]
+                })
+            return _mock_response(200, self._balance_response())
+
+        mock_session.get.side_effect = _side_effect
+        results = client.get_all_account_balances()
+        assert len(results) == 2  # Inactive 1つを除外
+        assert {r.account_id for r in results} == {"77800/P120136", "77800/T126816"}

--- a/tests/test_saxo_oauth_init.py
+++ b/tests/test_saxo_oauth_init.py
@@ -1,0 +1,118 @@
+"""scripts/saxo_oauth_init.py ユニットテスト
+
+CLI 全体の E2E は手動 (ブラウザ介入必要)。本ファイルは pure-function 部分
+(loopback validation, idempotency guard, chmod) を対象。
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def saxo_oauth_init():
+    """scripts/saxo_oauth_init.py を module として import (path 経由)"""
+    spec = importlib.util.spec_from_file_location(
+        "saxo_oauth_init",
+        Path(__file__).parent.parent / "scripts" / "saxo_oauth_init.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestValidateLoopbackHost:
+    def test_localhost_ok(self, saxo_oauth_init):
+        saxo_oauth_init._validate_loopback_host("localhost")
+
+    def test_127_ok(self, saxo_oauth_init):
+        saxo_oauth_init._validate_loopback_host("127.0.0.1")
+
+    def test_ipv6_loopback_ok(self, saxo_oauth_init):
+        saxo_oauth_init._validate_loopback_host("::1")
+
+    def test_none_rejected(self, saxo_oauth_init):
+        with pytest.raises(SystemExit, match="could not be parsed"):
+            saxo_oauth_init._validate_loopback_host(None)
+
+    def test_external_ip_rejected(self, saxo_oauth_init):
+        with pytest.raises(SystemExit, match="must be a loopback"):
+            saxo_oauth_init._validate_loopback_host("8.8.8.8")
+
+    def test_0_0_0_0_rejected(self, saxo_oauth_init):
+        with pytest.raises(SystemExit, match="must be a loopback"):
+            saxo_oauth_init._validate_loopback_host("0.0.0.0")
+
+    def test_external_hostname_rejected(self, saxo_oauth_init):
+        with pytest.raises(SystemExit, match="must be 'localhost'"):
+            saxo_oauth_init._validate_loopback_host("evil.example.com")
+
+
+class TestEnsureDbFileMode:
+    def test_chmod_sets_600(self, saxo_oauth_init, tmp_path):
+        f = tmp_path / "test.duckdb"
+        f.write_bytes(b"dummy")
+        f.chmod(0o644)
+        saxo_oauth_init._ensure_db_file_mode(f)
+        mode = stat.S_IMODE(f.stat().st_mode)
+        assert mode == 0o600
+
+    def test_missing_file_no_error(self, saxo_oauth_init, tmp_path):
+        """存在しない path は no-op (chmod 試行しない)"""
+        f = tmp_path / "nonexistent.duckdb"
+        saxo_oauth_init._ensure_db_file_mode(f)
+        assert not f.exists()
+
+    def test_idempotent_on_already_600(self, saxo_oauth_init, tmp_path):
+        f = tmp_path / "test.duckdb"
+        f.write_bytes(b"dummy")
+        f.chmod(0o600)
+        saxo_oauth_init._ensure_db_file_mode(f)
+        assert stat.S_IMODE(f.stat().st_mode) == 0o600
+
+
+class TestCallbackHandlerIdempotency:
+    def test_second_callback_ignored_after_event_set(self, saxo_oauth_init):
+        """do_GET が 2回呼ばれても result.code/error は最初の値を保持"""
+        result = saxo_oauth_init._CallbackResult()
+        handler_cls = saxo_oauth_init._make_handler(
+            expected_state="STATE_X", result=result,
+        )
+
+        result.code = "first_code"
+        result.state = "STATE_X"
+        result.event.set()
+
+        from unittest.mock import MagicMock
+        fake_self = MagicMock()  # no spec so wfile/end_headers are auto-mocked
+        fake_self.path = "/callback?code=second_code&state=STATE_X"
+
+        handler_cls.do_GET(fake_self)
+
+        assert result.code == "first_code"
+        assert result.error is None
+
+    def test_state_mismatch_does_not_leak_expected(self, saxo_oauth_init):
+        """state mismatch error message に expected_state を含めない (secret 漏洩防止)"""
+        result = saxo_oauth_init._CallbackResult()
+        secret = "EXPECTED_SECRET_VALUE_192bit"
+        handler_cls = saxo_oauth_init._make_handler(
+            expected_state=secret, result=result,
+        )
+
+        from unittest.mock import MagicMock
+        fake_self = MagicMock()
+        fake_self.path = "/callback?code=x&state=WRONG_STATE"
+
+        handler_cls.do_GET(fake_self)
+
+        assert result.error is not None
+        assert secret not in result.error, (
+            f"expected_state ({secret}) leaked into error message: {result.error}"
+        )


### PR DESCRIPTION
## Summary

- **ADR-025**: Saxo OpenAPI 認証情報の配置設計 (App Key/Secret → `.env`、token → DuckDB、ADR-009 思想と一貫)
- **ADR-026**: 外部 API field 解釈規律 (provider 中立、推測禁止・citation 必須・raw dict 禁止)
- Saxo Live API で 7口座残高 + open positions 取得を実装、`AccountBalance` dataclass で意味的アクセサを提供

## 起案契機

本セッション中に Saxo `CashBalance` を「取引可能額」と変数名から誤推測し、T126816 の usable cash を **$96 (正解 $649) と 6.7倍 過小報告**。トレード sizing 判断の根幹を誤らせる致命的バグ。

→ Saxo 固有の対症療法 (ADR-025) に加え、規律を一般化した ADR-026 を併設。`docs/api/<provider>/` 構造 + 意味的アクセサ + CLAUDE.md ルール の3段で構造的に再発防止。

## 主な変更点

### 新規ファイル (13)

- `docs/adr/025-saxo-openapi-auth.md`, `docs/adr/026-external-api-field-discipline.md`
- `docs/api/README.md`, `policy.md`, `TEMPLATE.md`
- `docs/api/saxo/README.md`, `balance-fields.md`, `endpoints.md`, `rate-limits.md`
- `src/saxo_client.py` (369行、SaxoConfig + SaxoClient + AccountBalance dataclass)
- `scripts/saxo_oauth_init.py` (156行、初回認可 CLI、localhost callback)
- `tests/test_db_auth_tokens.py` (17 tests)、`tests/test_saxo_client.py` (20 tests)

### 既存ファイル変更 (3)

- `src/db.py`: `auth_tokens` テーブル + `save_token` / `get_active_token` / `revoke_token` 追加 (+91 行)
- `CLAUDE.md`: Structure 表に `docs/api/` 追加、Data Sources に Saxo 追加、新セクション「外部 API 統合 (ADR-026)」(+9 行)
- `docs/code-review-checklist.md`: 新セクション 4「外部 API 統合」(+12 行)

## テスト

- **新規 37 tests、全プロジェクト 97/97 PASS** (回帰なし)
- 「`spending_power` と `settled` の乖離を検出」テストで本セッションの誤りを回帰防止
- OAuth フロー (initial / refresh / rotation / 失敗時 revoke) を mock HTTP で網羅

## Live 動作確認済

- Saxo Live OAuth 完走 (browser → callback → DB 保存)
- 7 sub-accounts 列挙、P120136 `spending_power=21,901 JPY ($138)`、T126816 `spending_power=103,099 JPY ($649)`
- SOXL 1株ポジション (Uic 46780 @ OpenPrice 176.00) 確認

## 関連

- 既存 FRED/Tiingo/yfinance の retroactive 文書化は **後続タスク** (PR 範囲外)
- `/portfolio-sync` skill (SessionStart に口座状態を自動注入) は別 ADR で起案予定

## Test plan

- [ ] `python -m pytest tests/test_db_auth_tokens.py tests/test_saxo_client.py -v` → 37/37 PASS
- [ ] `python -m pytest -q` → 全体 97/97 PASS
- [ ] (Live、手動) `python scripts/saxo_oauth_init.py` で再認可 → balance/positions 取得が動作
- [ ] `docs/api/saxo/balance-fields.md` の field 定義が公式 schema と整合 (citation URL 確認)
- [ ] `grep -rn '\["[A-Z][a-zA-Z]*"\]' src/ scripts/` で raw dict access が `src/*_client.py` 外にないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)