### PR TITLE
feat(trades): 発注ライフサイクル status 列 (ADR-027)

### DIFF
--- a/.claude/skills/entry-analysis/SKILL.md
+++ b/.claude/skills/entry-analysis/SKILL.md
@@ -288,6 +288,7 @@ tid = db.add_trade(
         "[シナリオ] {選択したシナリオの要約}. "
         "[注文] entry=${entry} TP=${tp} SL=${sl}"
     ),
+    status="{placed/filled}",  # ADR-027: 即時約定なら filled(既定)、resting指値/IFD-OCOは placed
 )
 print(f"Trade #{tid} recorded")
 conn.close()
@@ -329,3 +330,4 @@ PYEOF
 - heredoc内でトリプルクォート禁止（グローバルCLAUDE.md）
 - {対象銘柄} のプレースホルダーは実行時にユーザー指定の銘柄に置き換える
 - ユーザーがtrade記録を希望しない場合（分析だけ見たい場合）はadd_trade()をスキップ可
+- ADR-027: resting指値/IFD-OCOを発注時点で記録する場合は `status="placed"` を渡す。約定確認後に `update_trade_status(tid, "filled")`、不発キャンセル時は `update_trade_status(tid, "cancelled", notes=...)`。物理削除はしない（発注=意思決定の事実を残す）

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ learning/data/*.duckdb
 learning/data/*.duckdb.wal
 *.parquet.bak
 
+# Research artifacts (large binaries / raw intraday dumps — regenerable, not for VCS)
+data/research/polygon_intraday/
+data/research/charts_*/
+
 # Python
 __pycache__/
 .pytest_cache/

--- a/docs/adr/024-regime-historical-persistence.md
+++ b/docs/adr/024-regime-historical-persistence.md
@@ -1,0 +1,165 @@
+# ADR-024: regime_assessments の同日複数スナップショット許容
+
+Status: proposed
+Date: 2026-05-21
+
+## Context
+
+ADR-009 で `regime_assessments` テーブルに「判定時の生入力値スナップショット (6カラム)」を埋め込む設計を採用した。これにより「VIXが25〜30の時のレジーム判定精度」のような後検証が可能になった。
+
+しかし運用を進める中で、以下の問題が顕在化した:
+
+**問題1: 同日複数の判定が記録できない (上書き発生)**
+
+現在の `save_regime()` 実装は `DELETE FROM regime_assessments WHERE date = ?` → `INSERT` の upsert 動作。同日内に複数回 `/update-regime` を実行すると、最後の値以外は失われる。
+
+**問題2: 日中のレジーム遷移が観測できない**
+
+2026-05-21 の実例:
+- 08:11 JST 保存: `risk_on (score 0.71)` (5/20 close ベース、VIX 17.44 / Brent $105.40 / VIX_TERM steep_contango)
+- 20:30 JST 再判定: `neutral (score 0.50)` (5/21 リアルタイム値、VIX 17.84 / Brent $107.09 / VIX_TERM 通常コンタンゴへ後退)
+
+朝→夕で **risk_on → neutral のレジーム遷移** が発生したが、現状の upsert 仕様では朝のスナップショットを上書きするため、DB 上ではこの遷移が記録されない。
+
+**問題3: ADR-009 の精神との不整合**
+
+ADR-009 は「振り返り不能」を解消するため入力値スナップショットを必須化した。しかし同日内の複数判定が消える設計では「いつレジームが転換したか」「日中の市場動揺が判定にどう影響したか」を後検証できず、結果として ADR-009 の動機が部分的に未達成。
+
+**問題4: イベント因果検証の精度低下**
+
+`/review-events` で「あるイベントの3日後 review」を行う際、当日のレジーム遷移が記録されていないと「イベント発火時のレジーム」と「イベント結果確定時のレジーム」を分離できない。同日内で複数の重要 catalyst (例: FOMC議事録 + NVDA earnings) が発火する日には、特に精度が低下する。
+
+## Research
+
+### 既存設計の確認
+
+`src/db.py`:
+```python
+def save_regime(self, dt: date, ...):
+    self.conn.execute("DELETE FROM regime_assessments WHERE date = ?", [dt])
+    self.conn.execute("INSERT INTO regime_assessments (date, ...) VALUES (?, ...)", [...])
+```
+
+`date` カラムが primary key 相当の制約として機能。
+
+### 時系列スナップショットの一般的設計パターン
+
+- **append-only ledger pattern**: イミュータブルな履歴テーブルを保持、最新値は ORDER BY + LIMIT 1 で取得
+- **bi-temporal pattern**: valid_time と recorded_time を分離管理 (会計・規制業界で一般的)
+- **slowly changing dimension type 2**: 各 record に valid_from / valid_to を持たせる
+
+Master Sensei の用途では bi-temporal や SCD2 は過剰、シンプルな append-only ledger が適切。
+
+### 既存類似テーブル
+
+- `predictions`: id (auto-increment) PK、append-only、created_at で時系列保持。outcome 列で resolve 反映
+- `events`: id (auto-increment) PK、append-only
+- `knowledge`: id (auto-increment) PK、validated_at で再検証時刻保持
+
+`predictions`/`events`/`knowledge` は既に append-only パターン。`regime_assessments` だけが upsert で例外的。
+
+## Options
+
+### A: id PK 化 + assessed_at カラム追加 (一体化案)
+
+既存テーブルの schema を変更:
+- `id` を auto-increment PK に変更
+- `assessed_at` (TIMESTAMP WITH TIME ZONE) カラム追加
+- `date` は維持 (日次集約用、`assessed_at::DATE` で導出可能だが UI/SQL 簡便化のため保持)
+- 同日複数 record 許容
+
+| 長所 | 短所 |
+|------|------|
+| 完全な append-only 化、ADR-009 精神に合致 | get_latest_regime, get_regime_by_date 等の SELECT 系を全部改修必要 |
+| 1テーブルで完結、データ統合性高い | 既存クエリ (`WHERE date = ?` で1行想定) が破綻 |
+| `predictions`/`events` と一貫した設計 | 移行コスト中 (既存17 record に assessed_at = date 12:00 JST 補完) |
+
+### B: 履歴テーブル分離 (`regime_history` 新設)
+
+- 既存 `regime_assessments` は最新値のみ (現状動作維持、upsert 継続)
+- 新規 `regime_history` を作成、`save_regime()` 内で append-only に書く
+- 読み側: 既存ユースケースは `regime_assessments` のまま、履歴検索のみ `regime_history` 使用
+
+| 長所 | 短所 |
+|------|------|
+| 既存コードへの影響が最小 (SELECT 系は全部そのまま動く) | テーブル2つに分割、同期リスク (save_regime で両方書く必要) |
+| 段階的移行可能、リスク低い | 「最新値」と「履歴」の整合性責任が save_regime に集中 |
+| `predictions` の `outcome` カラムパターンと類似発想 | スキーマ重複 (両テーブルに同じカラム) |
+
+### C: 現状維持 (上書き継続) + 運用注意
+
+- ADR-003 「データ未更新で前日と同一」ならスキップに加え、「同日2回目の評価は記録しない」運用を明文化
+- 同日内の重要遷移は condition.md の文章で記録
+
+| 長所 | 短所 |
+|------|------|
+| 実装変更ゼロ | ADR-009 の精神と乖離継続 |
+| | 同日遷移の振り返り不能、`/review-events` 精度低下継続 |
+
+### D: (date, slot) 複合 PK
+
+- slot enum (`'eod'`, `'intraday'`, `'pre-open'` など) を追加
+- 同日複数 record を slot 単位で許容
+
+| 長所 | 短所 |
+|------|------|
+| 構造化された slot 概念で意図明示 | slot 判定ロジックが複雑、自動化困難 |
+| | 1日3-4スナップショットの上限を強制 (intraday 高頻度には対応不可) |
+
+## Decision
+
+> **Option B (履歴テーブル分離) を採用する。** 以下を実施する:
+>
+> 1. **新規テーブル `regime_history` を作成する。** schema は `regime_assessments` と同じカラムに加え、`id INTEGER PRIMARY KEY` (auto-increment) と `assessed_at TIMESTAMP WITH TIME ZONE NOT NULL` を持つ。append-only (DELETE/UPDATE は禁止)。
+>
+> 2. **`save_regime()` を改修する。**
+>    - 既存の `regime_assessments` への DELETE→INSERT (最新値保持) は維持
+>    - 同時に `regime_history` にも INSERT する (assessed_at = `now_jst()`)
+>
+> 3. **既存データの移行スクリプトを作成する。** `regime_assessments` の全 record (17件、2026-03 以降) を `regime_history` に `assessed_at = date + 12:00 JST` で補完移行する。
+>
+> 4. **新規メソッド `get_regime_history(date_range)` を追加する。** 期間内の全スナップショットを `assessed_at ASC` で返す。`/review-events` から呼び出し可能にする。
+>
+> 5. **既存の get メソッドは無変更。** `get_latest_regime()`, `get_regime_by_date()` などは `regime_assessments` を引き続き参照。
+
+## Why Option B
+
+- **Option A** が理論的には最も綺麗だが、SenseiDB の全 get メソッド改修が必要で、誤って既存挙動を壊すリスクが大きい。特に `/update-regime` `/scan-market` `/review-events` が依存しており、今夜の予測 ID 6 deadline (5/22 05:00 JST) 前後で破壊を起こすと観測ロスが大きい
+- **Option B** は段階的・低リスク。既存 SELECT 系は1行も変えず、save_regime のみ拡張。同期リスクは save_regime 内に集中するため単体テストで担保可能
+- **Option C** は ADR-009 の精神と乖離するため不採用
+- **Option D** は slot enum の自動判定が困難 (実装側の負担増)
+
+## Charter Impact
+
+- Charter 5.x「自己評価メカニズム」: `/review-events` の評価精度向上が期待される (イベント発火時 vs 結果確定時のレジーム分離可能)
+- ADR-009 との関係: ADR-009 の「振り返り不能」解消の動機を **同日内遷移にも拡張**する追補位置付け
+
+## Consequences
+
+### 反映先
+
+- `src/db.py`:
+  - `regime_history` テーブル定義追加
+  - `save_regime()` に `regime_history` への INSERT 追加
+  - `get_regime_history(start_date, end_date)` メソッド追加
+- マイグレーションスクリプト: `scripts/migrate_024_regime_history.py` (既存 record の補完移行)
+- テスト: `test_db_regime_history.py` (append-only 動作確認、同期検証)
+- skill `/update-regime`: コード変更不要 (save_regime の呼び出し API は変わらない)
+- skill `/review-events`: `get_regime_history` を活用するよう改善 (別タスク)
+
+### トレードオフ
+
+- ストレージ増加: 1日複数 record で履歴増加、ただし1 record < 1KB なので年間 365 record でも数十 MB 程度
+- save_regime の I/O 倍増 (2 INSERT)、ただし無視できる範囲
+- スキーマ重複: 同じカラム定義が2テーブルに存在、変更時の同期注意
+
+### 見直しトリガー
+
+- `regime_history` の record 数が 1日 100件超になった場合 (高頻度判定運用時) → スキーマ最適化検討
+- ADR-009 の他のテーブル (predictions, knowledge) でも同様の同日複数 record 需要が顕在化した場合 → 全体的な append-only 戦略の再検討
+
+### 実装タイミング
+
+- 設計確定: 本 ADR で 2026-05-21
+- 実装: 次セッション (5/22 以降、米寄付直前を避ける時間帯)
+- 既存予測 ID 6 (deadline 5/22 05:00 JST) の解決後に実施推奨

--- a/docs/adr/027-trade-order-lifecycle-status.md
+++ b/docs/adr/027-trade-order-lifecycle-status.md
@@ -1,0 +1,80 @@
+# ADR-027: トレードの発注ライフサイクル（status 列）
+
+Status: accepted
+Date: 2026-05-29
+
+## Context
+
+Session 35 で、`trades` #11（SOXL long $215 GTC 指値 IFD-OCO）が**約定済みポジションとして残存**している問題が判明した。
+
+- `/entry-analysis`（ADR-018）は後知恵バイアス排除のため**発注時点で `add_trade()` を呼ぶ**。#11 もこの規律に従い、発注時の MAP 分析を `entry_reasoning` に正しく記録していた。
+- しかし $215 指値は不発に終わり（発注後セッション安値 $224.19、$215 未到達）、ユーザーが注文をキャンセルした。
+- `trades` は ADR-015 で「約定した1ラウンドトリップ = 1行」「`entry_date`/`entry_price` NOT NULL（約定前提）」と設計されており、**「発注したが約定しなかった」を表現する状態が無い**。
+- 結果、#11 は `exit_date IS NULL`＝「保有中ポジション」と区別がつかず、次セッション以降で「SOXL 1株保有」と誤認するリスクがあった。
+
+### 検討した代替案
+
+| 案 | 評価 |
+|----|------|
+| 物理削除（`delete_trade`） | **却下**。ADR-018 が発注時点で記録した「意思決定の事実」を捨てる。後知恵バイアス排除の目的に反する |
+| `predictions` で代用 | **却下**。ADR-018 は entry-analysis からの予測自動起票を明示的にスコープ外化。order fill は市場予測ではなく Brier を汚す |
+| `account_transactions`（生データ層）で吸収 | **不可**。約定事実のみを記録する層。不発・キャンセルは約定でないため載らない |
+| decision 層を別テーブルに分離 | 設計的には最も綺麗だが重い。将来の選択肢として保留 |
+| **`trades` に `status` 列を追加（採用）** | 軽量。意思決定の記録（`entry_reasoning`）を保持したまま、結末を表現できる |
+
+## Decision
+
+`trades` に発注ライフサイクルを表す `status` 列を追加する。
+
+### status の値
+
+| 値 | 意味 | P&L |
+|----|------|-----|
+| `placed` | 発注済み・約定待ち（resting limit / IFD-OCO 等） | なし |
+| `filled` | 約定済み。実ポジション=ラウンドトリップの起点 | close 後に確定 |
+| `cancelled` | 発注後に手動キャンセル（約定せず） | なし |
+| `expired` | GTC 等が失効（約定せず） | なし |
+
+- **デフォルトは `filled`**。後方互換のため: 既存の `add_trade()` 呼び出しと過去データは全て「実際にエントリーした取引」を表していた。
+- `/entry-analysis` が resting 指値を発注時点で記録する場合は `status='placed'` を明示的に渡す。
+
+### 統計・ポジション判定の規律
+
+- **保有ポジション = `status='filled' AND exit_date IS NULL`**。`placed`/`cancelled`/`expired` はポジションではない。
+- `get_open_trades()` はこの定義に変更する（従来の `exit_date IS NULL` のみは placed を誤って含む）。
+- 未約定の発注一覧は `get_pending_orders()`（`status='placed'`）で取得する。
+- 勝率・平均損益など成績集計は `status='filled'` のみを対象とする。
+
+### マイグレーション（ADR-020 方式）
+
+- 新規 DB: `CREATE TABLE` に `status VARCHAR NOT NULL DEFAULT 'filled'` を含める。
+- 既存 DB: `information_schema.columns` で列の有無を確認し、無ければ `ALTER TABLE trades ADD COLUMN status VARCHAR DEFAULT 'filled'`。既存全行は `filled` にバックフィルされる（過去データは全て実約定だったため正しい）。
+- 個別データ修正（#11 → `cancelled`）はマイグレーションではなく `update_trade_status()` の単発呼び出しで行う。
+
+### 状態遷移
+
+最小版では遷移ステートマシンは実装せず、`status` 値の集合バリデーションのみ行う（ADR-018 の複雑性バイアス回避方針を踏襲）。妥当な遷移は `placed → {filled, cancelled, expired}` だが、強制はしない。
+
+## Implementation
+
+### 変更ファイル
+- `src/db.py`:
+  - `trades` DDL に `status` 追加 + マイグレーション
+  - `add_trade(..., status='filled')` — バリデーション + INSERT に追加
+  - `update_trade_status(trade_id, status, *, notes=None)` — 新規
+  - `get_open_trades()` — `status='filled' AND exit_date IS NULL` に変更
+  - `get_pending_orders()` — 新規
+- `tests/test_db.py` — 上記のテスト
+- `.claude/skills/entry-analysis/SKILL.md` — resting 指値時の `status='placed'` 指針
+- `CLAUDE.md` — 必要に応じて trades の Write 基準を補足
+
+### データ修正
+- `update_trade_status(11, 'cancelled', notes='$215 GTC IFD-OCO 不発→キャンセル。発注後安値 $224.19 で $215 未到達 (Session 35 確認)')`
+
+## Consequences
+
+- 「発注したが約定しなかった」意思決定が履歴として残る（ADR-018 の後知恵バイアス排除と整合）。
+- placed 注文がポジションと誤認されなくなる（#11 問題の再発防止）。
+- 成績集計は `status='filled'` フィルタが必須になる。
+- `trades` が「決定」と「執行」を1テーブルで兼ねる歪みは残る。decision 層の完全分離が必要になった場合は別 ADR で対応する。
+- 見直しトリガー: placed→filled の遷移を Saxo API 約定確認と自動同期する仕組みを将来検討（現状は手動 `update_trade_status`）。

--- a/docs/condition.md
+++ b/docs/condition.md
@@ -1,6 +1,316 @@
 # Condition
 
-Last updated: 2026-05-24 14:45 JST (session 34、Memorial Day weekend Day1、米5/22引け値取得 + 予測ID6 FALSE resolve + Iran 60日休戦MOU draft 5/23合意 + Cleveland Fed nowcast PCE 4.18% + SOXLスィング多角分析). **次の catalyst: 5/24 (日) afternoon JST Trump+仲介団 Iran deal 公式発表予定 → 5/26 (火) 22:30 JST US Memorial Day明け寄付で weekend headlines 一括 pricing-in、SOXL gap riskレンジ +3-5% / -5-8% 想定**
+Last updated: 2026-05-31 (session 37 継続、週末。市場データは 5/29 金曜引けが最新)。**trade #11 ($215 GTC 指値) 不発キャンセル → ADR-027 で trades に status 列導入し cancelled として記録**。scan-market 2件登録（5/28 record close + MRVL beat）、レジーム **risk_on (VIX normal→low)** を 5/29 付で記録。現在オープンポジション 0 件・口座状況変化なし
+
+---
+
+## ⚡ Session 37 Handoff (2026-05-29 18:01 JST、米寄付前)
+
+### 確定事項
+
+#### データ更新 (18:01 JST)
+`update_data.py` 実行。マクロ 9 系列最新 5/29、日足 10 銘柄 5/28、5分足 8 銘柄 5/28 15:55 ET。SOXL 5/28 close $224.63。
+
+#### trade #11 整合性: ADR-027 で「発注ライフサイクル」を導入
+- **問題**: #11 (SOXL long $215 GTC IFD-OCO、5/29 00:18 JST 発注時点で記録) が約定済みポジションとして残存。だが $215 指値は不発（発注後レギュラー安値 $224.19、$215 未到達）でユーザーがキャンセル。`trades` は約定前提スキーマで「不発」を表現できず、保有ポジションと誤認するリスク。
+- **判断**: 物理削除は ADR-018（後知恵バイアス排除=発注時点の意思決定を記録）に反するため却下。**ADR-027** で `trades.status` (placed/filled/cancelled/expired) を追加。既存全行 filled にバックフィル、#11 を **cancelled** として note 付きで記録。
+- **波及**: `get_open_trades()` を `status='filled' AND exit_date IS NULL` に変更（placed/cancelled を除外）、`get_pending_orders()`・`update_trade_status()` 追加、`add_trade(status=)` 追加。entry-analysis SKILL.md に placed/filled 指針追記。全 704 テスト緑。
+- **結果**: オープンポジション 0 件・pending 0 件。口座「変化なし」と DB 一致。
+
+#### データ被覆の学び（ユーザー指摘「pre の値も認識して」）
+5分足 parquet (Tiingo IEX) は **ET 09:30–15:55 のレギュラー時間のみ**（プレ/アフター 0 本）。GTC/延長時間有効の指値はプレ・アフターでも約定しうるため、レギュラー安値だけで「不発」を断定するのは不完全な検証。価格・安値・高値を語る時は参照データが延長時間を含むか確認し、進行中のプレマーケットはリアルタイム取得（yfinance/Tiingo）で補う。
+
+#### /scan-market (5/28 22:31 → 5/29 19:47 JST、2件登録)
+- **market/positive** (5/29 05:00 JST = 5/28 引け): S&P500・Nasdaq 揃って史上最高値 (各+0.5%)、4月 PCE 3年高にも関わらず。AI infra 主導 (MSFT/ORCL/PLTR +3-4%、SNOW +30%)。**SOXL 5/27 $217.98 → 5/28 $224.63 (+3.05%、Parquet 確認)** で前日 chip selloff (-3.46%) を全戻し。前日の AI capex sustainability doubt thesis を市場が1日で否定。
+- **semiconductor/positive** (5/28 05:05 JST = 5/27 AMC): MRVL Q1 FY27 beat+raise (rev $2.418B 過去最高 +28%、EPS $0.80 vs $0.75、FY27/28 上方、AI networking 需要)、aftermarket +5% → 5/28 premarket -2% sell-the-news (K-016)。SEC 8-K (mrvl-20260527.htm) で確定。
+- スキップ: Iran 60日MOU (5/23 既登録 slow-walk)、oil (Parquet 91.0 vs web 97.5 乖離・routine)、Section 232 (7/1 Commerce 報告まで進展なし)、Fed (今週 discrete なし)。
+
+#### /update-regime (5/29 付で記録)
+- **risk_on (score +1.36)**。前回 5/27 risk_on から overall 不変だが **VIX 16.77→15.84 で normal→low に格上げ**、Brent 92.4→91.0 軟化。リスク選好やや強まる方向、5/28 record close と整合。
+- 入力スナップショット: VIX 15.84 / VIX3M 19.11 (ratio 0.829 steep_contango) / HY 2.71 / YC 0.46 / Brent 91.01 / USD 119.29 (ADR-009)。
+- 記録日は `today_jst()` でなく明示 5/29（データが 5/29 金曜引け＝最新、週末で新規データなし）。
+
+---
+
+## ⚡ Session 36 Handoff (2026-05-28 13:43 - 5/29 00:10 JST、米寄付前 → 米セッション中盤)
+
+### 今日のセッションで確定した事項
+
+#### Saxo OAuth 不通 + Excel transactions 経由の代替検証 (13:43-14:30 JST)
+
+5/27 22:27 JST 期限の refresh token (実効寿命 ~1h 仕様、ADR-025 update 候補) が ~15h 放置で期限切れ + ユーザー側 login trouble で `scripts/saxo_oauth_init.py` 再認証不能。代替として **ユーザー提供の Saxo Excel `Transactions_22013145_2026-03-11_2026-05-28.xlsx`** で取引履歴を分析:
+- 期間: 2026-03-11 〜 2026-05-28、計 16 約定 / 8 ラウンドトリップ、口座 T126816 のみ抽出
+- 確定 P&L 合計 **-96,901 JPY** (5/27 売却分未計上)、SOXS 4/14-5/18 -92,349 JPY が損失の主因 (50株 $21.60→$10.05)
+- 入金 200,000 JPY → 累積 -49% 損失
+
+#### trade DB 整合性 2 段修正 (14:30-23:30 JST)
+
+| 操作 | 内容 | 結果 |
+|------|------|------|
+| **#9 close** | 5/27 buy @$215 → 5/28 sell @$242.43 (実約定) を `SenseiDB.close_trade()` で正規 close | exit_date=2026-05-28、pnl_usd=+$27.43、holding_days=1 |
+| **#8 第1段** | Excel に存在しない fictitious と誤判断し DELETE → entry_reasoning に「P120136 口座」記載発覚 → 復元（exit fields NULL） | 過小復元 (anchoring bias による誤 DELETE) |
+| **#8 第2段** | /scan-market 実行中に **前回 (5/27 21:36) metadata で trade_8_closed factual 記録**発見、exit 情報を確定値で完全復元 | exit=2026-05-26 @$210、pnl=+$34/+19.32%、holding_days=5 |
+
+→ Excel = T126816 抽出のみ、**P120136 口座の trade #8 は別 export 必要**だったことが原因。学びとして `feedback_destructive_action_full_field_check.md` を memory に保存 (DB DELETE 提案前は全 field SELECT + 抽出スコープ明示)。
+
+#### /scan-market 実行 (22:24 JST、2 events 登録)
+
+前回 5/27 21:36 JST 以降 25h ウィンドウ:
+
+| 日時(JST) | カテゴリ | impact | サマリ |
+|-----------|---------|--------|--------|
+| 5/28 05:00 | semiconductor | **negative** | 5/27 chip brutal selloff: **QCOM -13% (2020以来最悪)**、INTC -8%、MU -6%、SOXX -5%、NVDA -1% 選別的。SOXL gap-up open $242.66 → close $217.98 (intraday open→close -10.2%、prev close 比 -3.46%) |
+| 5/28 21:30 | fed | neutral | Q1 GDP 2nd 2.0% 不変、PCE +4.5% 不変、**Core PCE +4.4% (+0.1pp 上方修正、marginal hawkish)** |
+
+#### /update-regime 実行 (22:33 JST、記録スキップ)
+
+| 指標 | 今日 (5/28) | 前日 (5/27) | 判定 |
+|------|------------|------------|------|
+| overall | risk_on (+1.07) | risk_on | 完全一致 |
+| VIX/HY/YC/Brent/USD | 微変動 | 微変動 | 全 6 sub-regime 不変 |
+
+ADR-003 「前日と変化がない場合は記録不要」に従い記録スキップ判断 (ユーザー承認待ち)。
+
+#### 5/27 chip selloff の真因特定 (00:00 JST)
+
+ユーザー「209 まで下げの原因は？」要請に対し他銘柄横断調査:
+
+**根源: Intel Northland Capital downgrade** (5/26-5/27、Outperform → Market Perform、price target suspended)
+
+**thesis**:
+1. AI capex sustainability 疑問 — ハイパースケーラー営業 CF 100% を chip 投入、業界 $260B 債務
+2. INTC サーバー CPU シェア 54.9% (-3.7pp)、AMD +2.3pp / ARM +1.4pp で侵食
+3. 強い Q1 にもかかわらず rally 織り込み済
+
+**結果は chip 内 rotation**:
+
+| 銘柄 | 5/28 intraday low | 種別 |
+|------|------------------|------|
+| INTC | -4.48% | Northland thesis 主犯 |
+| AVGO/MU/MRVL | -1.9〜-2.5% | hyperscaler exposure (=AI capex 懸念) |
+| AMD | -0.41% | INTC からシェア奪取で勝者側 |
+| QCOM | -0.81% | mobile/auto で hyperscaler 露出薄 |
+| NVDA | -0.65% | AI king、selective resilience |
+
+**broad market 無傷の検証**: SPY -0.16% / QQQ -0.42% intraday low、VIX -2.09% (panic 否定)、TLT -0.04% (金利懸念なし)、Brent -1.28% (Iran 無視)。**systemic 売りではなく chip 内ローテーション** が確定。
+
+#### SOXL monitor 設置・運用 (22:44 JST 〜)
+
+`scripts/monitor_soxl_2026-05-28.py` 新設、yfinance polling で SOXL/SOXX/MU/NVDA/AMD を実時間追跡。
+
+| version | poll | trigger 種類 |
+|---------|------|-------------|
+| v1 (22:44-23:25) | 180s | LONG_DIP_zone (210/205/200) / SHORT_RALLY_zone (230/235) / VOL_FLAG / DEEP_DIP / GAP_FILL |
+| **v2 (23:25-)** | **60s** | v1 + **REVERSAL_UP/DOWN** (session low/high から ±1.5% bounce + NVDA leadership 確認) |
+
+**5/28 intraday の発火履歴**:
+
+| 時刻 (JST) | trigger | SOXL |
+|-----------|---------|------|
+| 22:47 | LONG_DIP_210 | $209.87 (寄付 -3.72%) |
+| 23:05 | (session low) | **$208.30 (-4.44%、V-bottom)** |
+| 23:14 | VOL_FLAG_4 | $218.11 (+4.7% bounce from low) |
+| 00:01-0:04 | VOL_FLAG_3 / REVERSAL_UP / VOL_FLAG_4 | $221.86 → $224.02 |
+
+→ session range **$208.30〜$224.02 = +7.5%**、まさに教科書的 V 反転。REVERSAL_UP は NVDA leadership 条件で false positive を上手く抑止 (22:47 の初期 bounce では NVDA -0.16% で不発、00:02 で NVDA +0.02% 確認後に発火)。
+
+#### /entry-analysis 実行 + trade #10 記録 (23:38 JST)
+
+| 軸 | 評価 |
+|----|------|
+| Regime | risk_on (+1.07) |
+| SOXL Flow | bullish (+0.70)、1d -3.46% / 3d +22.2% / σ +1.76 |
+| σ position (5/27 close) | +1.76σ、+1.5σ=$210.29、+2σ=$224.91 |
+| K-029 status | 3d +22.2% で +25% 閾値 1 step 直下 |
+| 5/27 candle | O=H=$242.66, L=$204, C=$217.98 = shooting star + long lower wick |
+
+**trade #10 記録**: SOXL long、entry $210 limit、TP $220、SL $206、1 株、confidence 0.50、setup `long_shallow_dip_1.5sigma_support_post_chip_selloff`。シナリオ A (mean reversion 30%) + B (range 40%) の双方で約定可能性 ~55% 想定。
+
+#### OCO 再提案 (00:05 JST、$223.85 起点で再評価)
+
+V 反転完了後、A1 ($210) が deep OTM 化。**SOXS は day-trade 不可制約** (ユーザー指定) で SOXL only に絞り再設計:
+
+| # | エントリー | TP | SL | R:R | fill 確率 |
+|---|----------|----|----|------|----------|
+| **推奨 ①** | **$215 limit buy** | $223 | $210 | **1:1.6** | **~50%** |
+| ② | $226 stop buy | $235 | $221 | 1:1.8 | ~25% |
+| ③ | $228 limit short (K-031 で A1 cancel 必須) | $218 | $233 | 1:2.0 | ~30% |
+
+→ ① 採用なら A1 と 2-tier ladder ($210 + $215)、平均 $212.5 ロング狙い。
+
+### 重要な観察 (バイアス点検)
+
+- **「Excel に無いから fictitious」anchoring bias で trade #8 を誤 DELETE**: entry_reasoning text に P120136 口座明記があったのを読まずに DELETE 提案、ユーザー承認後実行 → 復元 → さらに前回 metadata で完全 exit info 発見の二段救済。学び memory に保存 (feedback_destructive_action_full_field_check)
+- **broad market 横ばい中の chip 局所 selloff は rotation**: Northland INTC thesis 起点で「AI capex 投資先 (INTC/AVGO/MU/MRVL) を売り、勝者側 (AMD/QCOM) を買う」。systemic 売りと誤認しないこと
+- **K-029 (3d +25% mean reversion) は閾値 1 step 下でも近似発動**: 5/27 3d +22.2% で +25% に未達ながら、5/27 brutal selloff (-10% intraday) + 5/28 朝の continuation → V 反転は K-029 の自然な path として整合
+- **monitor の REVERSAL trigger 設計が機能**: NVDA leadership 条件が「単なる bounce」と「真の反転」を分離、22:47 初動では未発火、00:02 NVDA 復帰確認後に正発火
+- **A1 ($210 limit) は時間経過で deep OTM 化**: V 反転後の price action で fill 確率激減、insurance 扱いに格下げ判断
+
+### 未解決予測: **0 件** (trade #9 prediction 紐付け遡及未実施 = ADR-003 violation 候補継続)
+
+### Saxo 状況サマリー (Excel 経由データ + 推定)
+
+| 口座 | 状態 |
+|------|------|
+| T126816 | trade #9 close 済 (+$27.43、$242.43 寄付 fill)、現在 flat |
+| P120136 | trade #8 close 済 (+$34、$210 で 5/26 fill 確認)、T+2 入金 5/28 受渡完了想定 |
+
+OAuth 復活後、closedpositions API で T126816/P120136 両方の 5/27-5/28 fill 確定値 audit + trade #10 (もし発注実行されれば) ライブ確認の優先順位高。
+
+### 次セッション開始時の優先順位
+
+1. `TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST'` 時刻確認
+2. **monitor 状態確認**: bash task `bgk8h2hbf` が稼働中か (~5:00 JST 5/29 まで)、output tail
+3. **MRVL/Dell/Costco AMC 結果確認** (5/29 05:00 JST = 5/28 ET 引け直後)
+4. **SOXL 5/29 米寄付 (22:30 JST) gap 反応**: MRVL beat なら gap up でロング/ショート再評価、miss なら gap down で A1 ($210) 約定可能性高
+5. **trade #10 fill 状況確認**: Saxo IFD-OCO の $210 limit が実発注されたか、約定 or 未約定
+6. **Saxo OAuth 再認証** (login trouble 解消後、refresh token chain 再構築)
+7. trade #9 prediction 遡及起草 (ADR-003 violation 解消)
+8. `/scan-market` 5/29 状況 (MRVL/Dell/Costco 反応、Iran 続報、Section 232 など)
+9. `/update-regime` データ更新後の再判定
+10. ADR-025 update 検討 (Saxo refresh token 実効寿命 ~1h vs 想定 60-90日 の乖離)
+11. K-029 evidence に 5/27→5/28 case (premarket gap +10% → 寄付直後 -14.5% fade → 翌日 V 反転) 追記候補
+12. **新 knowledge 候補**: 「broad market 横ばい中の chip selloff は rotation thesis (Northland INTC downgrade パターン) を疑う」(n=1、要追加観察)
+
+---
+
+## ⚡ Session 35 Handoff (2026-05-27 21:23-22:00 JST、米プレマーケット前)
+
+### 今日のセッションで確定した事項
+
+#### Saxo OAuth 再認証 (21:27 JST)
+
+前回 5/27 01:41 JST の refresh token chain (実効寿命 ~1h) が ~19h 放置で expire → `python scripts/saxo_oauth_init.py` でブラウザ再認証実施、access+refresh token 再保存。**Saxo refresh token の実効寿命 ≈ 1h** は ADR-025 設計時の想定 (60-90日) と大きく乖離、今後セッション間で chain 維持するには 1h 以内に必ず API 呼出が必要 (将来 ADR-025 update 候補)。
+
+#### Saxo Live snapshot + Open Orders 取得 (21:28 / 21:55 JST)
+
+| 口座 | 通貨 | NAV | spending_power | settled cash | T+2 未決済 | 状態 |
+|------|------|-----|----------------|--------------|-----------|------|
+| T126816 | JPY | 104,633 | 68,750 | 103,275 | -34,525（買付） | **SOXL 1株 含み益 (stale PnL +35,707 JPY)** |
+| P120136 | JPY | 55,387 | 55,387 | 22,075 | +33,312（売却） | trade #8 利確分入金待ち |
+
+**Trade #9 (open)**: T126816 SOXL Long 1株 @ **$215.00** (entry 5/26 11:54 ET = 5/27 00:54 JST)、setup `swing_long_IFD_pullback_T126816`、regime_at_entry `risk_on`。
+
+**Working orders (T126816、OCO リンク)**:
+| OrderId | BuySell | Type | Price | 用途 |
+|---------|---------|------|-------|------|
+| 5406862623 | Sell 1 | **Limit @ $230** | TP | 寄付 cross で執行 |
+| 5406862624 | Sell 1 | **StopIfTraded @ $215** | **SL = BREAKEVEN** | リスク 0 |
+
+注: 前回 metadata の「IFD $205 BUY × 2 still Working」は今回確認時不在（filled or cancelled）。
+
+**Trade #8 (closed)**: P120136 SOXL Long 1株 $176 → $210 (5/21→5/26、+$34 / +19.3% / 5d hold)、T+2 入金 33,312 JPY 待ち。**prediction_id 未紐付け = ADR-003 violation 候補 (次セッションで遡及起草要)**。
+
+#### /scan-market 実行 (21:34 JST、1 event 登録)
+
+前回 5/27 01:30 JST 以降 20h を6カテゴリ調査。
+
+| 日時(JST) | カテゴリ | impact | サマリ |
+|-----------|---------|--------|--------|
+| 5/27 05:00 | market | **positive** | 5/26 US close 双子 record high: S&P 7,519.12 +0.61% / Nasdaq 26,656.18 +1.19%、MU +19% で一時 $1T mkt cap touch (UBS upgrade $535→$1,625 効果)、SOXL +15.38%、NVDA -1.07% 単独 laggard で **4連続 post-earnings slide パターン継続** |
+
+スキップ 7件: Iran slow-walk 継続 (K-009 既パターン)、Fed Polymarket zero-cut dominant pricing、MU $1T mkt cap (downstream)、UAE OPEC exit (4/28 既登録)、CRM Q1 FY27 result (未公表)、Brent/WTI daily、Section 232 新規進展なし。
+
+#### SOXL 5/27 premarket gap up 観察 (21:55 JST)
+
+ユーザー「premarket 確認」要請に対し yfinance + Polygon で交差検証:
+
+| 時刻 (ET) | 価格 | 出来高 | 出典 |
+|-----------|------|--------|------|
+| 5/26 15:55 (regular close 前) | $227.89 | 71,292 | Polygon 5m |
+| 5/26 19:55 (after-hours 最終) | $230.40 | 36,110 | Polygon 5m |
+| 5/27 07:05 (premarket 開始) | $244.15 | 0 (仲値) | yfinance 5m prepost |
+| 5/27 08:44 (~21:44 JST) | **$252.29** | 0 (仲値) | yfinance 1m prepost |
+
+→ **5/26 close → 5/27 premarket gap = +9.5%**、SOXX +3.3% (3x leverage 整合)。Saxo PnL ($10.72 = $225.72) は完全 stale（subscription 範囲外、`LastUpdated: 0001-01-01`、`PriceTypeBid/Ask: NoAccess`）。
+
+**ドライバー未特定**: scan-market では gap を説明する specific news 未発見。Asian/European session で発生した何か（具体的 catalyst 未確認、要 5/28 review-events）。
+
+#### TP $230 据置判定 (21:58 JST、ユーザー確定)
+
+**Limit Sell @ $230 の挙動**: $230 「以上」で売る = 寄付 cross 価格 ≥ $230 なら **cross 価格で fill**（$230 ではない）。premarket $252 維持なら fill ~$245-255 = +$30-40 / +14-19% per share 期待。
+
+判断根拠:
+- TP は「キャップ」ではなく「下限保証付き寄付売り注文」
+- SL $215 = breakeven、リスクゼロ
+- K-029 mean reversion 閾値超過 (5/19 底 $135 → 現 $252 = **+86.7%**、trade #6 entry $176 → +43.2%) で chase は危険
+- 寄付 cross が $230 割れる急落のみが「もっと取れた」事案、それは Limit @ $230 残しでも対応可
+
+### 重要な観察 (バイアス点検)
+
+- **Saxo Live data が stale な前提を見落としていた**: PnL $10.72 = $225.72 を current mark と誤認、premarket $252 で見直すまで recommendation の base price が誤っていた。**今後 Saxo 経由 quote は必ず yfinance/Polygon と cross verify**
+- **trade #9 prediction 未紐付け**: 次セッションで「現 mark $252 → 5/30 米引け までの方向性」を確信度付きで遡及起草要
+- **利確 → 高値ロール ($210→$215) は結果オーライ**: trade #8 5/26 exit $210 → trade #9 entry $215 → premarket $252 で +$37 浮動利益、$5 高でのロールが正解 (ただし事前評価では K-029 警告を出していた、運の要素大)
+- **5/27 premarket gap +9.5% のドライバー未特定**: AH $230 → premarket $244 の +6% overnight gap は何か specific catalyst のはず、5/28 review-events で要確認
+
+### 未解決予測: **0 件** (trade #9 に prediction 未紐付け、要遡及起草)
+
+### Session 35 延長 (2026-05-28 00:00-00:30 JST、米寄付後 1h46min)
+
+#### Trade #9 TP fill 確定 (寄付直後)
+
+ユーザー Saxo notification 受信。yfinance で fill 価格 verify:
+
+| 項目 | 値 |
+|------|---|
+| 5/26 close (yf) | $230.35 |
+| premarket peak (5/27 08:44 ET) | $252.29 |
+| **寄付 cross (5/27 09:30 ET)** | **$242.66** (Volume 12.87M) |
+| **TP $230 Limit Sell 約定価格** | **$242.66 想定** (cross > $230 で open 価格 fill) |
+| Entry | $215.00 |
+| Per-share profit (gross) | **+$27.66 / +12.87%** |
+| JPY 換算 (@160 JPY/USD) | +4,426 JPY gross、commission -1,600 JPY 控除後 **~+2,800 JPY net** |
+
+→ **寄付 ATH 近辺で出れた、ほぼ optimal exit**。Saxo API は refresh token chain 再切れで actual fill 確認は再認証後 (ユーザー pending)。
+
+#### SOXL 寄付後急落 — K-029 mean reversion 完全 validated
+
+| 時刻 (ET) | SOXL | from open |
+|----------|------|-----------|
+| 09:30 (open) | $242.66 | – |
+| 09:37 | $223.37 | -8.0% |
+| 09:47 | $211.55 | -12.8% |
+| 11:16 (00:16 JST 5/28) | **$207.61** | **-14.5%** |
+
+→ premarket gap +10% → 寄付 1分以内に剥がれ、1h46min で **-14.5%** の急落。**TP $230 据置判断 + K-029 警告が完璧に validated**。
+
+判断比較:
+- TP $230 据置 (実行) → +$27.66 確定
+- 仮 TP $260 raise → 未約定 → 現価 $207.61 で **含み損 -$7.39 / -3.4%**
+- 仮 Phase 3 opportunistic SOXX (即発火 -3% trigger) → SOXX も -10% で **-9,500 JPY loss**
+
+→ **TP 据置 + flat default が完全正解**。Phase 3 opportunistic plan は trigger 「30min 以内に -3%」では速すぎて **falling knife を掴む設計**、今後 plan refine 候補 (60-90min settling + volume 確認後)。
+
+#### 重要 lesson (今回明確に validated)
+
+- **K-029 (急騰後 +25% mean reversion 閾値)**: 5/19 底 $135 → premarket $252 = +86.7% で閾値超過時の警告が **同日中に発動**。lesson の predictive power 確認、knowledge K-029 evidence に今回 case 追記 (upsert、last_verified_date 2026-05-28、evidence 517 chars)
+- **「premarket gap up +10% = 75% 陽線継続」hypothesis (n=12)**: 今回 fade 17% 側、サンプル不足で structural 化見送り判断は妥当
+- **opportunistic re-entry の trigger 設計**: 「-3% in 30min」は速すぎる falling knife、refine 必要
+
+#### TP fill 後の bottom hunting 判定 (02:35 JST、ユーザー「下がってませんか？エントリーすべき？」に対応)
+
+13:35 ET snapshot: SOXL $213.45 (-7.34% from $230.35)、SOXX $559.91 (-2.45%)、TECL $219.01 (-2.78%)、SPY -0.17% / QQQ -0.40% / VIX 16.78 (-1.35%)。**半導体限定 sector rotation**、market broad は無事。SOXL bottom $208.82 (13:05 ET) から +2.2% bounce 進行中だが **volume 580K→265K で declining = ショートカバー主導の薄い反発**。
+
+**判定: エントリー見送り (wait)**。理由:
+1. CRM/SNOW/HPQ AMC が 2.5h 後 binary risk、Saxo IFD-OCO は AH 反応不可
+2. Dead cat bounce パターン疑い、second leg down リスク
+3. K-029 mean reversion 未完了 (5/19 底 + ATR 圏 ~$170 まで戻る余地)
+4. R/R 計算で期待値 ~0、disciplined entry に値しない
+
+バイアス点検: 「下がってるから入りたい」は anchoring bias (premarket $252 / 寄付 $242 に anchor)。本日 +$27/+12.87% 獲得済みで即時 press の経済合理性低い、「勝った後は休む」 discipline 推奨。
+
+### 次セッション開始時の優先順位
+
+1. `TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M JST'` 時刻確認
+2. **Saxo OAuth 再認証** (refresh token chain 再切れで API 不可)
+3. **trade #9 actual fill price 確定** (Saxo ClosedPositions API)、DB trades テーブル update (exit_price, exit_date, pnl_usd, pnl_pct, holding_days, exit_reasoning, discipline_score)
+4. **trade #9 prediction 遡及起草** (ADR-003 violation 解消、確信度・期限・反証条件込み)
+5. **CRM/SNOW/HPQ AMC 結果確認** (5/28 05:00 JST = 5/27 ET AMC、enterprise software triple-header AI capex test)
+6. `/review-events` 候補: 5/27 SOXL gap up → -14.5% fade (K-029 validated impact)、Iran slow-walk
+7. **K-029 knowledge entry の confidence 引き上げ** (新規 case として追加観察)
+8. **opportunistic re-entry plan refine** (trigger 条件の改善: 60-90min settling 後 + volume 確認)
+9. **5/29 21:30 JST April PCE deflator** = 週内最重要 macro、Cleveland Fed nowcast 4.18% verify
+10. Saxo refresh token chain 維持の改善検討 (ADR-025 update、~1h 寿命 vs 60-90日想定の乖離)
 
 ---
 

--- a/src/db.py
+++ b/src/db.py
@@ -180,9 +180,21 @@ class SenseiDB:
                 discipline_score INTEGER,
                 review_notes TEXT,
                 prediction_id INTEGER,
+                status VARCHAR NOT NULL DEFAULT 'filled',
                 created_at TIMESTAMP DEFAULT current_timestamp
             )
         """)
+        # ADR-027 migration: add status column to existing DBs (backfill 'filled')
+        trade_cols = {
+            row[0] for row in self.conn.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'trades' AND table_schema = 'main'"
+            ).fetchall()
+        }
+        if "status" not in trade_cols:
+            self.conn.execute(
+                "ALTER TABLE trades ADD COLUMN status VARCHAR DEFAULT 'filled'"
+            )
         self.conn.execute("CREATE SEQUENCE IF NOT EXISTS trades_id_seq START 1")
 
         self.conn.execute("""
@@ -586,6 +598,9 @@ class SenseiDB:
 
     # ── trades (ADR-015) ──
 
+    # ADR-027: 発注ライフサイクルの状態
+    TRADE_STATUSES = ("placed", "filled", "cancelled", "expired")
+
     def add_trade(
         self,
         instrument: str,
@@ -601,19 +616,22 @@ class SenseiDB:
         setup_type: str = None,
         entry_reasoning: str = None,
         prediction_id: int = None,
+        status: str = "filled",
     ) -> int:
         if confidence_at_entry is not None and not (0.0 <= confidence_at_entry <= 1.0):
             raise ValueError("confidence_at_entry must be 0.0-1.0")
+        if status not in self.TRADE_STATUSES:
+            raise ValueError(f"status must be one of {self.TRADE_STATUSES}")
         tid = self.conn.execute("SELECT nextval('trades_id_seq')").fetchone()[0]
         self.conn.execute(
             "INSERT INTO trades "
             "(id, instrument, direction, entry_date, entry_price, quantity, "
             "regime_at_entry, vix_at_entry, brent_at_entry, confidence_at_entry, "
-            "setup_type, entry_reasoning, prediction_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "setup_type, entry_reasoning, prediction_id, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [tid, instrument, direction, entry_date, entry_price, quantity,
              regime_at_entry, vix_at_entry, brent_at_entry, confidence_at_entry,
-             setup_type, entry_reasoning, prediction_id],
+             setup_type, entry_reasoning, prediction_id, status],
         )
         return tid
 
@@ -659,9 +677,47 @@ class SenseiDB:
             [discipline_score, review_notes, trade_id],
         )
 
+    def update_trade_status(self, trade_id: int, status: str, *, notes: str = None):
+        """発注ライフサイクルの結末を記録する (ADR-027)。
+
+        placed → {filled, cancelled, expired} の遷移を想定。物理削除はしない
+        （発注=意思決定の事実を履歴として残す。ADR-018 の後知恵バイアス排除と整合）。
+        notes を渡すと review_notes に追記する。
+        """
+        if status not in self.TRADE_STATUSES:
+            raise ValueError(f"status must be one of {self.TRADE_STATUSES}")
+        row = self.conn.execute(
+            "SELECT review_notes FROM trades WHERE id = ?", [trade_id]
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"Trade {trade_id} not found")
+        if notes is not None:
+            existing = row[0]
+            merged = f"{existing}\n{notes}" if existing else notes
+            self.conn.execute(
+                "UPDATE trades SET status = ?, review_notes = ? WHERE id = ?",
+                [status, merged, trade_id],
+            )
+        else:
+            self.conn.execute(
+                "UPDATE trades SET status = ? WHERE id = ?", [status, trade_id]
+            )
+
     def get_open_trades(self) -> list[dict]:
+        """保有中ポジション = 約定済みかつ未手仕舞い (ADR-027)。
+
+        placed/cancelled/expired はポジションではないので含めない。
+        """
         rows = self.conn.execute(
-            "SELECT * FROM trades WHERE exit_date IS NULL ORDER BY entry_date"
+            "SELECT * FROM trades WHERE status = 'filled' AND exit_date IS NULL "
+            "ORDER BY entry_date"
+        ).fetchdf().to_dict("records")
+        return rows
+
+    def get_pending_orders(self) -> list[dict]:
+        """未約定の発注一覧 (status='placed', ADR-027)。"""
+        rows = self.conn.execute(
+            "SELECT * FROM trades WHERE status = 'placed' ORDER BY entry_date"
         ).fetchdf().to_dict("records")
         return rows
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -528,6 +528,7 @@ class TestTrades:
             "regime_at_entry", "vix_at_entry", "brent_at_entry",
             "confidence_at_entry", "setup_type", "entry_reasoning", "exit_reasoning",
             "discipline_score", "review_notes", "prediction_id", "created_at",
+            "status",
         }
         assert expected <= col_names
 
@@ -629,3 +630,100 @@ class TestTrades:
         open_trades = db.get_open_trades()
         assert len(open_trades) == 1
         assert open_trades[0]["instrument"] == "SOXL"
+
+    # ── ADR-027: 発注ライフサイクル (status) ──
+
+    def test_add_trade_defaults_status_filled(self, db):
+        """後方互換: status 未指定の add_trade は filled。"""
+        tid = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 3, 31), entry_price=42.949, quantity=28,
+        )
+        status = db.conn.execute(
+            "SELECT status FROM trades WHERE id = ?", [tid]
+        ).fetchone()[0]
+        assert status == "filled"
+
+    def test_add_trade_accepts_placed_status(self, db):
+        """resting 指値は status='placed' で発注時点を記録できる。"""
+        tid = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+            status="placed",
+        )
+        status = db.conn.execute(
+            "SELECT status FROM trades WHERE id = ?", [tid]
+        ).fetchone()[0]
+        assert status == "placed"
+
+    def test_add_trade_rejects_invalid_status(self, db):
+        with pytest.raises(ValueError):
+            db.add_trade(
+                instrument="SOXL", direction="long",
+                entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+                status="bogus",
+            )
+
+    def test_update_trade_status_to_cancelled(self, db):
+        """発注→不発キャンセルを結末として記録する（履歴は残す）。"""
+        tid = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+            status="placed",
+        )
+        db.update_trade_status(tid, "cancelled", notes="$215 指値が不発")
+        row = db.conn.execute(
+            "SELECT status, review_notes FROM trades WHERE id = ?", [tid]
+        ).fetchone()
+        assert row[0] == "cancelled"
+        assert "$215" in row[1]
+
+    def test_update_trade_status_not_found_raises(self, db):
+        with pytest.raises(ValueError):
+            db.update_trade_status(99999, "cancelled")
+
+    def test_update_trade_status_rejects_invalid(self, db):
+        tid = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+        )
+        with pytest.raises(ValueError):
+            db.update_trade_status(tid, "bogus")
+
+    def test_get_open_trades_excludes_placed(self, db):
+        """未約定の placed 注文はポジションではない（#11 問題の再発防止）。"""
+        db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+            status="placed",
+        )
+        filled = db.add_trade(
+            instrument="TQQQ", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=83.0, quantity=2,
+            status="filled",
+        )
+        open_trades = db.get_open_trades()
+        assert [t["id"] for t in open_trades] == [filled]
+
+    def test_get_open_trades_excludes_cancelled(self, db):
+        tid = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+            status="placed",
+        )
+        db.update_trade_status(tid, "cancelled")
+        assert db.get_open_trades() == []
+
+    def test_get_pending_orders_returns_placed(self, db):
+        placed = db.add_trade(
+            instrument="SOXL", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=215.0, quantity=1,
+            status="placed",
+        )
+        db.add_trade(
+            instrument="TQQQ", direction="long",
+            entry_date=date(2026, 5, 29), entry_price=83.0, quantity=2,
+            status="filled",
+        )
+        pending = db.get_pending_orders()
+        assert [t["id"] for t in pending] == [placed]


### PR DESCRIPTION
## 概要

`trades` に発注ライフサイクルの `status` 列 (placed/filled/cancelled/expired) を導入する (ADR-027)。発注時点で意思決定を記録する ADR-018 の規律を保ったまま、「発注したが約定しなかった」を表現可能にする。

## 背景

trade #11 (SOXL long $215 GTC IFD-OCO) が不発キャンセルにもかかわらず約定済みポジションとして残存し、「SOXL 1株保有」と誤認するリスクがあった。物理削除は ADR-018（後知恵バイアス排除）に反するため却下し、status 列で結末を表現する設計を採用。

## 変更

- `add_trade(status=)` 追加 + status バリデーション
- `update_trade_status()` 追加（placed→filled/cancelled/expired、物理削除しない）
- `get_open_trades()` を `status='filled' AND exit_date IS NULL` に変更
- `get_pending_orders()` 追加（`status='placed'`）
- 既存 DB 向けマイグレーション（status 列を 'filled' でバックフィル）
- entry-analysis SKILL に placed/filled 指針追記
- ADR-027 (accepted) 追加
- 併せて: ADR-024 draft (proposed)、session 36-37 handoff、研究データ (109MB) を .gitignore

## テスト

`tests/test_db.py` 69 passed（status バリデーション・遷移・get_pending_orders を含む）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)